### PR TITLE
[discrete_dp]adjust figure sizes in lecture

### DIFF
--- a/lectures/discrete_dp.md
+++ b/lectures/discrete_dp.md
@@ -555,7 +555,7 @@ results.mc.stationary_distributions
 Here's the same information in a bar graph
 
 ```{figure} /_static/lecture_specific/discrete_dp/finite_dp_simple_og.png
-
+:scale: 90
 ```
 
 What happens if the agent is more patient?
@@ -569,7 +569,7 @@ results.mc.stationary_distributions
 If we look at the bar graph we can see the rightward shift in probability mass
 
 ```{figure} /_static/lecture_specific/discrete_dp/finite_dp_simple_og2.png
-
+:scale: 90
 ```
 
 ### State-Action Pair Formulation


### PR DESCRIPTION
This PR adjusts figures' size in [discrete_dp](https://python-advanced.quantecon.org/discrete_dp.html). I thought the current size is a little large.

```Left```: before this PR ```Right```: after this PR
![Screen Shot 2021-01-21 at 2 43 17 pm](https://user-images.githubusercontent.com/44494439/105277587-cb40bf80-5bf7-11eb-8b42-3934571e9a15.png)
![Screen Shot 2021-01-21 at 2 43 31 pm](https://user-images.githubusercontent.com/44494439/105277595-cf6cdd00-5bf7-11eb-8c13-c4d4d607a8f6.png)

cc: @mmcky 