### PR TITLE
[tax_smoothing_1] fix broken link

### DIFF
--- a/lectures/tax_smoothing_1.md
+++ b/lectures/tax_smoothing_1.md
@@ -171,8 +171,7 @@ This lecture describes:
   which a government faces exogenous time-varying interest rates for
   issuing one-period risk-free debt.
 
-A {doc}`sequel to this
-lecture <tax_smoothing_2>`
+A {doc}`sequel to this lecture <tax_smoothing_2>`
 describes applies Markov LQ control to settings in which a government
 issues risk-free debt of different maturities.
 


### PR DESCRIPTION
The link was split across two lines

Here is the comparison between ```MyST``` before this PR (```LHS```) and after this PR (```RHS```).  So it works ok after this PR.

![Screen Shot 2021-01-22 at 10 14 22 am](https://user-images.githubusercontent.com/44494439/105424124-e3b5e600-5c9a-11eb-956f-a50767257256.png)

cc: @mmcky 
