### PR TITLE
[tax_smoothing_3] fix broken link

### DIFF
--- a/lectures/tax_smoothing_3.md
+++ b/lectures/tax_smoothing_3.md
@@ -103,8 +103,7 @@ while $b_{t-1,t}$ is an endogenous state variable inherited from
 the past at time $t$ and $p^t_{t+1}$ is an exogenous state
 variable at time $t$.
 
-This is the same set-up as used {doc}`in this
-lecture <tax_smoothing_1>`.
+This is the same set-up as used {doc}`in this lecture <tax_smoothing_1>`.
 
 We will consider a situation in which the government faces “roll-over
 risk”.


### PR DESCRIPTION
The link was split across two lines.

Here is the comparison between ```MyST``` before this PR (```LHS```) and after this PR (```RHS```).  So it works ok after this PR.

![Screen Shot 2021-01-22 at 10 53 36 am](https://user-images.githubusercontent.com/44494439/105426974-4493ed00-5ca0-11eb-9d61-6b1a33a95fad.png)

cc: @mmcky 