### PR TITLE
[matsuyama]adjust figure sizes in lecture

### DIFF
--- a/lectures/matsuyama.md
+++ b/lectures/matsuyama.md
@@ -711,7 +711,7 @@ Dark colors indicate synchronization, while light colors indicate failure to syn
 
 (matsrep)=
 ```{figure} /_static/lecture_specific/matsuyama/matsuyama_14.png
-
+:scale: 60
 ```
 
 As you can see, larger values of $\rho$ translate to more synchronization.


### PR DESCRIPTION
This PR adjusts figures' size in [matsuyama](https://5ff58313b5fa65a2d9f2bcf6--wonderful-lalande-528d1c.netlify.app/matsuyama.html#basin-of-attraction). 

```Left```: before this PR ```Right```: after this PR
![Screen Shot 2021-01-22 at 5 26 36 pm](https://user-images.githubusercontent.com/44494439/105455052-04039600-5cd7-11eb-9147-e4f70c8c0048.png)

cc: @mmcky 