### PR TITLE
FIX: update math macros for argmaxx and argmin

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -12,4 +12,9 @@ sphinx:
   config:
     html_theme: quantecon_book_theme
     html_static_path: ['_static']
+    mathjax_config:
+      TeX:
+        Macros:
+          "argmax" : "arg\\,max"
+          "argmin" : "arg\\,min"
     mathjax_path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js


### PR DESCRIPTION
This PR updates mathjax math macros to fix https://github.com/QuantEcon/lecture-python-advanced.myst/issues/6