### PR TITLE
FIX: blockquote syntax when using displaymath

### DIFF
--- a/lectures/black_litterman.md
+++ b/lectures/black_litterman.md
@@ -529,13 +529,13 @@ labeled as iso-likelihood ellipses
 
 > **Remark:** More generally there is a class of density functions
 > that possesses this feature, i.e.
-> 
+>
 > $$
-> \exists g: \mathbb{R}_+ \mapsto \mathbb{R}_+ \ \ \text{ and } \ \ c \geq 0,
-> \ \ \text{s.t.  the density } \ \ f \ \ \text{of} \ \ Z  \ \
-> \text{ has the form } \quad f(z) = c g(z\cdot z)
-> $$
-> 
+  \exists g: \mathbb{R}_+ \mapsto \mathbb{R}_+ \ \ \text{ and } \ \ c \geq 0,
+  \ \ \text{s.t.  the density } \ \ f \ \ \text{of} \ \ Z  \ \
+  \text{ has the form } \quad f(z) = c g(z\cdot z)
+  $$
+>
 > This property is called **spherical symmetry** (see p 81. in Leamer
 > (1978) {cite}`leamer1978specification`).
 

--- a/lectures/chang_credible.md
+++ b/lectures/chang_credible.md
@@ -589,17 +589,15 @@ sustainable outcome:
 1. choose an initial $(w_0, \theta_0) \in S$;
 1. generate a sustainable outcome recursively by iterating on {eq}`chang501`, which we repeat here for convenience:
 
-> $$
-> \begin{aligned}
-> \hat h_t & = h(w_t,\theta_t) \\
-> m_t & = m(h_t, w_t,\theta_t) \\
-> x_t & = x(h_t, w_t,\theta_t) \\
-> w_{t+1} & = \chi(h_t, w_t,\theta_t)  \\
-> \theta_{t+1}  & = \Psi(h_t, w_t,\theta_t)
-> \end{aligned}
-> $$
-> 
-> 
+   $$
+   \begin{aligned}
+   \hat h_t & = h(w_t,\theta_t) \\
+   m_t & = m(h_t, w_t,\theta_t) \\
+   x_t & = x(h_t, w_t,\theta_t) \\
+   w_{t+1} & = \chi(h_t, w_t,\theta_t)  \\
+   \theta_{t+1}  & = \Psi(h_t, w_t,\theta_t)
+   \end{aligned}
+   $$
 
 ## Calculating the Set of Sustainable Promise-Value Pairs
 

--- a/lectures/growth_in_dles.md
+++ b/lectures/growth_in_dles.md
@@ -126,11 +126,9 @@ allocation solves the following planning problem.
 
 Choose $\{c_t, s_t, i_t, h_t, k_t, g_t\}_{t=0}^\infty$ to maximize
 
-> $$
-> - \frac{1}{2}\mathbb{E}\sum_{t=0}^\infty \beta^t [(s_t-b_t)\cdot(s_t - b_t) + g_t \cdot g_t]
-> $$
-> 
-> 
+$$
+-\frac{1}{2}\mathbb{E}\sum_{t=0}^\infty \beta^t [(s_t-b_t)\cdot(s_t - b_t) + g_t \cdot g_t]
+$$ 
 
 subject to the linear constraints
 


### PR DESCRIPTION
This PR fixes #16 to fix malformed `blockquote` context when using `$$` displaymath