### PR TITLE
[11_tax_smoothing_2] Adjust Figure Sizes

### DIFF
--- a/lectures/tax_smoothing_2.md
+++ b/lectures/tax_smoothing_2.md
@@ -808,7 +808,7 @@ x, u, w, t = lqm3.compute_sequence(x0, ts_length=300)
 ```{code-cell} python3
 # Plots of different maturities debt issuance
 
-fig, (ax1, ax2, ax3, ax4) = plt.subplots(1, 4, figsize=(16, 4))
+fig, (ax1, ax2, ax3, ax4) = plt.subplots(1, 4, figsize=(11, 3))
 ax1.plot(u[0, :])
 ax1.set_title('One-period debt issuance')
 ax1.set_xlabel('Time')


### PR DESCRIPTION
Hi @mmcky , this PR updates the figure sizes issue mentioned by #14 in lecture [11_tax_smoothing_2](https://github.com/QuantEcon/lecture-python-advanced.myst/compare/11_tax_smoothing_2%5D-Adjust-Figure-Sizes?expand=1#diff-9f30eae03bdefea6076385b7369a49dd166097745b326e7fe23f53febc23703c) (left: before the PR; right: with the PR):

![Screen Shot 2021-04-21 at 6 00 49 pm](https://user-images.githubusercontent.com/53931041/115518520-98c46280-a2cb-11eb-8018-5522ea2d8829.png)
