### PR TITLE
[12_tax_smoothing_3] Adjust Figure Sizes

### DIFF
--- a/lectures/tax_smoothing_3.md
+++ b/lectures/tax_smoothing_3.md
@@ -270,7 +270,7 @@ for i in range(T):
     tax[i, :] = S @ x[:, i] + M @ u[:, i]
 
 # Plot of debt issuance and taxation
-fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(16, 4))
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 3))
 ax1.plot(x[0, :])
 ax1.set_title('One-period debt issuance')
 ax1.set_xlabel('Time')
@@ -311,7 +311,7 @@ for i in range(T):
     tax[i, :] = S @ x[:, i] + M @ u[:, i]
 
 # Plot of debt issuance and taxation
-fig, (ax1, ax2) =  plt.subplots(1, 2, figsize=(16, 4))
+fig, (ax1, ax2) =  plt.subplots(1, 2, figsize=(12, 3))
 ax1.plot(x[0, :])
 ax1.set_title('One-period debt issuance')
 ax1.set_xlabel('Time')


### PR DESCRIPTION
Hi @mmcky , this PR updates the figure sizes issue mentioned by #14 in lecture [12_tax_smoothing_3](https://github.com/QuantEcon/lecture-python-advanced.myst/compare/12_tax_smoothing_3%5D-Adjust-Figure-Sizes?expand=1#diff-6344876214710579e6204d51fd13b59c2f327252aa69925d838dc6a433318fc5) (left: before the PR; right: with the PR):
![Screen Shot 2021-04-21 at 6 34 27 pm](https://user-images.githubusercontent.com/53931041/115523256-3b7ee000-a2d0-11eb-8bd5-7fdda9979c77.png)
