### PR TITLE
[22_permanent_income_dles] Adjust Figure Sizes

### DIFF
--- a/lectures/permanent_income_dles.md
+++ b/lectures/permanent_income_dles.md
@@ -281,7 +281,7 @@ The plot below quickly replicates the first two figures of
 that lecture and that  notebook to confirm that the solutions are the same
 
 ```{code-cell} python3
-fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(16, 5))
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 4))
 
 for i in range(25):
     econ1.compute_sequence(x0, ts_length=150)


### PR DESCRIPTION
Hi @mmcky , this PR updates the figure sizes issue mentioned by #14 in lecture [22_permanent_income_dles](https://github.com/QuantEcon/lecture-python-advanced.myst/compare/22_permanent_income_dles-Adjust-Figure-Sizes?expand=1#diff-866e056c05932e9c646e44b4b57892f8580c7ebe1d4135b975d305a902b4c3a9) (left: before the PR; right: with the PR):

![Screen Shot 2021-04-21 at 6 39 36 pm](https://user-images.githubusercontent.com/53931041/115526594-8a7a4480-a2d3-11eb-8e0f-4c3676c6eeec.png)
