### PR TITLE
[39_opt_tax_recur] Adjust Figure Sizes

### DIFF
--- a/lectures/opt_tax_recur.md
+++ b/lectures/opt_tax_recur.md
@@ -1113,7 +1113,7 @@ sim_seq_h[4] = time_example.G[sHist_h]
 sim_seq_l[5] = time_example.Θ[sHist_l] * sim_seq_l[1]
 sim_seq_h[5] = time_example.Θ[sHist_h] * sim_seq_h[1]
 
-fig, axes = plt.subplots(3, 2, figsize=(14, 10))
+fig, axes = plt.subplots(3, 2, figsize=(12, 8))
 titles = ['Consumption', 'Labor Supply', 'Government Debt',
           'Tax Rate', 'Government Spending', 'Output']
 
@@ -1390,7 +1390,7 @@ sim_bel[4] = log_example.G[sHist]
 sim_seq[5] = log_example.Θ[sHist] * sim_seq[1]
 sim_bel[5] = log_example.Θ[sHist] * sim_bel[1]
 
-fig, axes = plt.subplots(3, 2, figsize=(14, 10))
+fig, axes = plt.subplots(3, 2, figsize=(10, 6))
 titles = ['Consumption', 'Labor Supply', 'Government Debt',
           'Tax Rate', 'Government Spending', 'Output']
 


### PR DESCRIPTION
Hi @mmcky , this PR updates the figure sizes issue mentioned by #14 in lecture [39_opt_tax_recur.md ](https://github.com/QuantEcon/lecture-python-advanced.myst/compare/39_opt_tax_recur%5D-Adjust-Figure-Sizes?expand=1#diff-c3404237063f860075403d27e982cdd2c7277be621e461b4970abc3dc3059529) (It seems that the code cells in this lecture are unable to be executed).