### PR TITLE
[4_discrete_dp] Adjust Figure Sizes

### DIFF
--- a/lectures/discrete_dp.md
+++ b/lectures/discrete_dp.md
@@ -555,7 +555,9 @@ results.mc.stationary_distributions
 Here's the same information in a bar graph
 
 ```{figure} /_static/lecture_specific/discrete_dp/finite_dp_simple_og.png
-
+---
+scale: 70%
+---
 ```
 
 What happens if the agent is more patient?
@@ -569,7 +571,9 @@ results.mc.stationary_distributions
 If we look at the bar graph we can see the rightward shift in probability mass
 
 ```{figure} /_static/lecture_specific/discrete_dp/finite_dp_simple_og2.png
-
+---
+scale: 70%
+---
 ```
 
 ### State-Action Pair Formulation


### PR DESCRIPTION
Hi @mmcky , this PR updates the figure sizes issue mentioned by #14 in lecture [4_discrete_dp](https://github.com/QuantEcon/lecture-python-advanced.myst/compare/discrete_dp%5D-Adjust-Figure-Sizes?expand=1#diff-d11aea98d3064d266c4e277d6731d4451bcfe1031bc3a10b13a2f4f0030b060e) (left: before the PR; right: with the PR):
![Screen Shot 2021-04-21 at 10 01 36 pm](https://user-images.githubusercontent.com/53931041/115550657-75121400-a2ed-11eb-9b47-f4c911a5e418.png)
