### PR TITLE
[6_smoothing] Adjust Figure Sizes

### DIFF
--- a/lectures/smoothing.md
+++ b/lectures/smoothing.md
@@ -328,7 +328,7 @@ np.random.seed(s)  # Seeds get set the same for both economies
 out = complete_ss(β, b0, x0, A, C, S_y, 80)
 c_hist_com, b_hist_com, y_hist_com, x_hist_com = out
 
-fig, ax = plt.subplots(1, 2, figsize=(15, 5))
+fig, ax = plt.subplots(1, 2, figsize=(14, 4))
 
 # Consumption plots
 ax[0].set_title('Consumption and income')
@@ -918,7 +918,7 @@ c_bar, debt_complete = consumption_complete(cp)
 
 c_path, debt_path, y_path = consumption_incomplete(cp, s_path)
 
-fig, ax = plt.subplots(1, 2, figsize=(15, 5))
+fig, ax = plt.subplots(1, 2, figsize=(14, 4))
 
 ax[0].set_title('Consumption paths')
 ax[0].plot(np.arange(N_simul), c_path, label='incomplete market')


### PR DESCRIPTION
Hi @mmcky , this PR updates the figure sizes issue mentioned by #14 in lecture [6_smoothing](https://github.com/QuantEcon/lecture-python-advanced.myst/compare/6_smoothing%5D-Adjust-Figure-Sizes?expand=1#diff-41ad7530a662301a5f70e23ffe8b5ddfe8d6f9a10212cf7cfff7a2de46438c94) (left: before the PR; right: with the PR):

![Screen Shot 2021-04-21 at 10 12 57 pm](https://user-images.githubusercontent.com/53931041/115551989-1ea5d500-a2ef-11eb-85ec-71256caae05e.png)

![Screen Shot 2021-04-21 at 10 13 22 pm](https://user-images.githubusercontent.com/53931041/115552010-24031f80-a2ef-11eb-9f99-06a732cf31ec.png)
