### PR TITLE
[7_smoothing_tax] Adjust Figure Sizes

### DIFF
--- a/lectures/smoothing_tax.md
+++ b/lectures/smoothing_tax.md
@@ -251,7 +251,7 @@ c_bar, debt_complete = consumption_complete(cp)
 
 c_path, debt_path, y_path = consumption_incomplete(cp, s_path)
 
-fig, ax = plt.subplots(1, 2, figsize=(15, 5))
+fig, ax = plt.subplots(1, 2, figsize=(14, 4))
 
 ax[0].set_title('Consumption paths')
 ax[0].plot(np.arange(N_simul), c_path, label='incomplete market')
@@ -285,7 +285,7 @@ income $y_t$, notice that
 As indicated above, we relabel variables to acquire tax-smoothing interpretations of the complete markets and incomplete markets consumption-smoothing models.
 
 ```{code-cell} python3
-fig, ax = plt.subplots(1, 2, figsize=(15, 5))
+fig, ax = plt.subplots(1, 2, figsize=(14, 4))
 
 ax[0].set_title('Tax collection paths')
 ax[0].plot(np.arange(N_simul), c_path, label='incomplete market')


### PR DESCRIPTION
Hi @mmcky , this PR updates the figure sizes issue mentioned by #14 in lecture [7_smoothing_tax](https://github.com/QuantEcon/lecture-python-advanced.myst/compare/7_smoothing_tax%5D-Adjust-Figure-Sizes?expand=1#diff-247d1a6e2db0ffe50d593b5775dae277ca4da798af8dbc14a7d829e40db16d40) (left: before the PR; right: with the PR):

![Screen Shot 2021-04-21 at 10 21 11 pm](https://user-images.githubusercontent.com/53931041/115552912-2ade6200-a2f0-11eb-8042-874973cbcce2.png)

![Screen Shot 2021-04-21 at 10 21 32 pm](https://user-images.githubusercontent.com/53931041/115552926-2f0a7f80-a2f0-11eb-9854-25150cf0e237.png)

