### PR TITLE
[27_arma] Adjust Figure Sizes

### DIFF
--- a/lectures/arma.md
+++ b/lectures/arma.md
@@ -758,7 +758,7 @@ def quad_plot(arma):
 
     """
     num_rows, num_cols = 2, 2
-    fig, axes = plt.subplots(num_rows, num_cols, figsize=(12, 8))
+    fig, axes = plt.subplots(num_rows, num_cols, figsize=(10, 7))
     plot_functions = [plot_impulse_response,
                       plot_spectral_density,
                       plot_autocovariance,


### PR DESCRIPTION
Hi @mmcky , this PR updates the figure sizes issue mentioned by #14 in lecture [27_arma](https://github.com/QuantEcon/lecture-python-advanced.myst/compare/27_arma%5D-Adjust-Figure-Sizes?expand=1#diff-a07fee5b24acdc5aa349d9001ccb3c1a5b2a52e9af2e20b26601552d9553031f) (left: before the PR; right: with the PR):
![Screen Shot 2021-04-21 at 10 29 42 pm](https://user-images.githubusercontent.com/53931041/115554183-8c530080-a2f1-11eb-8c48-713dec5b27fa.png)
![Screen Shot 2021-04-21 at 10 30 00 pm](https://user-images.githubusercontent.com/53931041/115554193-8eb55a80-a2f1-11eb-95fd-8084f8fd5104.png)
![Screen Shot 2021-04-21 at 10 30 20 pm](https://user-images.githubusercontent.com/53931041/115554213-907f1e00-a2f1-11eb-912b-06b65694edfd.png)
![Screen Shot 2021-04-21 at 10 30 42 pm](https://user-images.githubusercontent.com/53931041/115554220-92e17800-a2f1-11eb-8092-c4997342a5b5.png)
![Screen Shot 2021-04-21 at 10 31 06 pm](https://user-images.githubusercontent.com/53931041/115554225-94ab3b80-a2f1-11eb-9c4e-004c3654c045.png)
