### PR TITLE
[35_BCG_complete_mkts] Adjust Figure Sizes

### DIFF
--- a/lectures/BCG_complete_mkts.md
+++ b/lectures/BCG_complete_mkts.md
@@ -1092,7 +1092,7 @@ the difference in the two models:
 epsgrid = np.linspace(-1,1,1000)
 
 
-fig, ax = plt.subplots(1,2,figsize=(15,7))
+fig, ax = plt.subplots(1,2,figsize=(14,6))
 ax[0].plot(epsgrid, mdl1.w11(epsgrid), color='black', label='Agent 1\'s endowment')
 ax[0].plot(epsgrid, mdl1.w21(epsgrid), color='blue', label='Agent 2\'s endowment')
 ax[0].plot(epsgrid, mdl1.Y(epsgrid,1), color='red', label=r'Production with $k=1$')


### PR DESCRIPTION
Hi @mmcky , this PR updates the figure sizes issue mentioned by #14 in lecture [35_BCG_complete_mkts](https://github.com/QuantEcon/lecture-python-advanced.myst/compare/35_BCG_complete_mkts%5D-Adjust-Figure-Sizes?expand=1#diff-eabfe17ee4d6f7807b8c5e4480dba5a49162f7458ea1d22546f32282fa39be3a).