### PR TITLE
[CI] fetch build cache from cache workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Download "build" folder (cache)
         uses: dawidd6/action-download-artifact@v2
         with:
-          workflow: publish.yml
+          workflow: cache.yml
           branch: main
           name: build-cache
           path: _build


### PR DESCRIPTION
This PR updates the cache to fetch `_build` folder from an independent `cache.yml` workflow which we can set to update on a schedule. 