### PR TITLE
[amss] [amss2] [amss3] scroll outputs

### DIFF
--- a/lectures/amss.md
+++ b/lectures/amss.md
@@ -403,7 +403,7 @@ on optimal taxation with state-contingent debt  sequential allocation implementa
 ```{code-cell} python3
 ---
 load: _static/lecture_specific/opt_tax_recur/sequential_allocation.py
-tags: [output_scroll]
+tags: [collapse-20]
 ---
 ```
 
@@ -759,7 +759,7 @@ Paths with circles are histories in which there is peace, while those with
 triangle denote war.
 
 ```{code-cell} python3
-:tags: ["output_scroll"]
+:tags: ["scroll-output"]
 # Initialize μgrid for value function iteration
 μ_grid = np.linspace(-0.7, 0.01, 300)
 
@@ -883,7 +883,7 @@ state-contingent debt (circles) and the economy with only a risk-free bond
 (triangles).
 
 ```{code-cell} python3
-:tags: ["output_scroll"]
+:tags: ["scroll-output"]
 log_example = LogUtility()
 log_example.transfers = True                    # Government can use transfers
 log_sequential = SequentialAllocation(log_example)  # Solve sequential problem

--- a/lectures/amss.md
+++ b/lectures/amss.md
@@ -759,6 +759,7 @@ Paths with circles are histories in which there is peace, while those with
 triangle denote war.
 
 ```{code-cell} python3
+:tags: ["output_scroll"]
 # Initialize μgrid for value function iteration
 μ_grid = np.linspace(-0.7, 0.01, 300)
 
@@ -882,6 +883,7 @@ state-contingent debt (circles) and the economy with only a risk-free bond
 (triangles).
 
 ```{code-cell} python3
+:tags: ["output_scroll"]
 log_example = LogUtility()
 log_example.transfers = True                    # Government can use transfers
 log_sequential = SequentialAllocation(log_example)  # Solve sequential problem

--- a/lectures/amss2.md
+++ b/lectures/amss2.md
@@ -433,6 +433,7 @@ debt equal to $b_0 = -1.038698407551764$.
 These graphs report outcomes for both the Lucas-Stokey economy with complete markets and the AMSS economy with one-period risk-free debt only.
 
 ```{code-cell} python3
+:tags: ["output_scroll"]
 μ_grid = np.linspace(-0.09, 0.1, 100)
 
 log_example = CRRAutility()

--- a/lectures/amss2.md
+++ b/lectures/amss2.md
@@ -279,21 +279,21 @@ The code is  mostly taken or adapted from the earlier lectures {doc}`optimal tax
 ```{code-cell} python3
 ---
 load: _static/lecture_specific/opt_tax_recur/sequential_allocation.py
-tags: [output_scroll]
+tags: [collapse-20]
 ---
 ```
 
 ```{code-cell} python3
 ---
 load: _static/lecture_specific/amss/recursive_allocation.py
-tags: [output_scroll]
+tags: [collapse-20]
 ---
 ```
 
 ```{code-cell} python3
 ---
 load: _static/lecture_specific/amss/utilities.py
-tags: [output_scroll]
+tags: [collapse-20]
 ---
 ```
 
@@ -433,7 +433,7 @@ debt equal to $b_0 = -1.038698407551764$.
 These graphs report outcomes for both the Lucas-Stokey economy with complete markets and the AMSS economy with one-period risk-free debt only.
 
 ```{code-cell} python3
-:tags: ["output_scroll"]
+:tags: ["scroll-output"]
 μ_grid = np.linspace(-0.09, 0.1, 100)
 
 log_example = CRRAutility()

--- a/lectures/amss3.md
+++ b/lectures/amss3.md
@@ -176,6 +176,7 @@ government debt equal to $-.5$.
 Here is a graph of a long simulation of 102000 periods.
 
 ```{code-cell} python3
+:tags: ["output_scroll"]
 μ_grid = np.linspace(-0.09, 0.1, 100)
 
 log_example = CRRAutility(π=(1 / 3) * np.ones((3, 3)),

--- a/lectures/amss3.md
+++ b/lectures/amss3.md
@@ -152,21 +152,21 @@ Here it is
 ```{code-cell} python3
 ---
 load: _static/lecture_specific/opt_tax_recur/sequential_allocation.py
-tags: [output_scroll]
+tags: [collapse-20]
 ---
 ```
 
 ```{code-cell} python3
 ---
 load: _static/lecture_specific/amss/recursive_allocation.py
-tags: [output_scroll]
+tags: [collapse-20]
 ---
 ```
 
 ```{code-cell} python3
 ---
 load: _static/lecture_specific/amss/utilities.py
-tags: [output_scroll]
+tags: [collapse-20]
 ---
 ```
 
@@ -176,7 +176,7 @@ government debt equal to $-.5$.
 Here is a graph of a long simulation of 102000 periods.
 
 ```{code-cell} python3
-:tags: ["output_scroll"]
+:tags: ["scroll-output"]
 μ_grid = np.linspace(-0.09, 0.1, 100)
 
 log_example = CRRAutility(π=(1 / 3) * np.ones((3, 3)),


### PR DESCRIPTION
HI @mmcky , this fix #65 and #64 in the following lectures:
- [amss](https://quantecon.github.io/lecture-python-advanced.myst/amss.html)
- [amss2](https://quantecon.github.io/lecture-python-advanced.myst/amss2.html)
- [amss3](https://quantecon.github.io/lecture-python-advanced.myst/amss3.html)

It also fixes `tags` for `collapse-20` in these lectures