### PR TITLE
FIX: add in cached _build folder due to plotly bug

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
+      - name: Download "build" folder (cache)
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: cache.yml
+          branch: main
+          name: build-cache
+          path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       # - name: Build PDF from LaTeX
       #   shell: bash -l {0}


### PR DESCRIPTION
Adding the `cached` build directory to the `publish` workflow fixes an issue involving interactive plots (such as `plotly`)

It appears that `html` build needs to be run first, prior to building `download notebooks` and/or `pdf` files so using the `cache` will resolve this.

The added benefit is that `publish` workflows will be a lot quicker. 