### PR TITLE
ENH: Upgrade sphinx-tojupyer=0.1.2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
     - jupyter-book==0.11.1
     - sphinx-multitoc-numbering==0.1.3
     - quantecon-book-theme==0.2.5
-    - sphinx-tojupyter==0.1.1
+    - sphinx-tojupyter==0.1.2
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==0.1.1
     - jupytext==1.11.2


### PR DESCRIPTION
This upgrades `sphinx-tojupyter==0.1.2` which brings in `chapter` context in equation numbers for the download notebooks. 