### PR TITLE
[asset-pricing-lph] enable myst-extensions including amsmath

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -3,6 +3,19 @@ author: Thomas J. Sargent & John Stachurski
 logo: _static/qe-logo-large.png
 description: This website presents a set of lectures on advanced quantitative economic modeling, designed and written by Thomas J. Sargent and John Stachurski.
 
+parse:
+  myst_enable_extensions:
+    - amsmath
+    - colon_fence
+    - deflist
+    - dollarmath
+    - html_admonition
+    - html_image
+    - linkify
+    - replacements
+    - smartquotes
+    - substitution
+
 execute:
   execute_notebooks: "cache"
   timeout: 7200   # 2 Hours


### PR DESCRIPTION
This will enable direct `\begin{align}` to be used by enabling the `amsmath` extension to myst-parser