### PR TITLE
[discrete_dp] a possible minor typo

### DIFF
--- a/lectures/discrete_dp.md
+++ b/lectures/discrete_dp.md
@@ -321,7 +321,7 @@ By the definition of greedy policies given above, this means that
 $$
 \sigma^*(s) \in \operatorname*{arg\,max}_{a \in A(s)}
     \left\{
-    r(s, a) + \beta \sum_{s' \in S} v^*(s') Q(s, \sigma(s), s')
+    r(s, a) + \beta \sum_{s' \in S} v^*(s') Q(s, a, s')
     \right\}
 \qquad (s \in S)
 $$


### PR DESCRIPTION
Hi @jstac , this PR corrects a possible minor typo in lecture [discrete_dp](https://python-advanced.quantecon.org/discrete_dp).