### PR TITLE
[ENH] Migrate exercise and solutions: Part 1

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -31,7 +31,7 @@ latex:
       targetname: quantecon-python-advanced.tex
 
 sphinx:
-  extra_extensions: [sphinx_multitoc_numbering, sphinxext.rediraffe, sphinx_tojupyter]
+  extra_extensions: [sphinx_multitoc_numbering, sphinxext.rediraffe, sphinx_tojupyter, sphinx_exercise, sphinx_togglebutton]
   config:
     nb_render_priority:
       html:

--- a/lectures/muth_kalman.md
+++ b/lectures/muth_kalman.md
@@ -233,13 +233,16 @@ With this tool at our disposal, let’s form the composite system and
 simulate it
 
 ```{code-cell} python3
+# Extract integer K1 from the nested array
+K1 = K1[0][0]
+
 # Create grand state-space for y_t, a_t as observed vars -- Use
 # stacking trick above
 Af = np.array([[ 1,      0,        0],
-               [K1[0][0], 1 - K1[0][0], K1[0][0] * σ_y],
+               [K1, 1 - K1, K1 * σ_y],
                [ 0,      0,        0]])
 Cf = np.array([[σ_x,        0],
-               [  0, K1[0][0] * σ_y],
+               [  0, K1 * σ_y],
                [  0,        1]])
 Gf = np.array([[1,  0, σ_y],
                [1, -1, σ_y]])

--- a/lectures/muth_kalman.md
+++ b/lectures/muth_kalman.md
@@ -233,7 +233,7 @@ With this tool at our disposal, let’s form the composite system and
 simulate it
 
 ```{code-cell} python3
-# Extract integer K1 from the nested array
+# Extract the scalar K1 from the nested array
 K1 = K1[0][0]
 
 # Create grand state-space for y_t, a_t as observed vars -- Use

--- a/lectures/muth_kalman.md
+++ b/lectures/muth_kalman.md
@@ -176,6 +176,9 @@ kmuth = Kalman(ss, x_hat_0, Σ_0)
 # representation
 S1, K1 = kmuth.stationary_values()
 
+# Extract scalars from the nested array
+S1, K1 = S1.item(), K1.item()
+
 # Form innovation representation state-space
 Ak, Ck, Gk, Hk = A, K1, G, 1
 
@@ -233,9 +236,6 @@ With this tool at our disposal, let’s form the composite system and
 simulate it
 
 ```{code-cell} python3
-# Extract the scalar K1 from the nested array
-K1 = K1[0][0]
-
 # Create grand state-space for y_t, a_t as observed vars -- Use
 # stacking trick above
 Af = np.array([[ 1,      0,        0],

--- a/lectures/muth_kalman.md
+++ b/lectures/muth_kalman.md
@@ -236,12 +236,11 @@ simulate it
 # Create grand state-space for y_t, a_t as observed vars -- Use
 # stacking trick above
 Af = np.array([[ 1,      0,        0],
-               [K1, 1 - K1, K1 * σ_y],
-               [ 0,      0,        0]],dtype=object)
+               [K1[0][0], 1 - K1[0][0], K1[0][0] * σ_y],
+               [ 0,      0,        0]])
 Cf = np.array([[σ_x,        0],
-               [  0, K1 * σ_y],
-               [  0,        1]],
-               dtype=object)
+               [  0, K1[0][0] * σ_y],
+               [  0,        1]])
 Gf = np.array([[1,  0, σ_y],
                [1, -1, σ_y]])
 

--- a/lectures/muth_kalman.md
+++ b/lectures/muth_kalman.md
@@ -176,7 +176,7 @@ kmuth = Kalman(ss, x_hat_0, Σ_0)
 # representation
 S1, K1 = kmuth.stationary_values()
 
-# Extract scalars from the nested array
+# Extract scalars from nested arrays
 S1, K1 = S1.item(), K1.item()
 
 # Form innovation representation state-space

--- a/lectures/muth_kalman.md
+++ b/lectures/muth_kalman.md
@@ -237,10 +237,11 @@ simulate it
 # stacking trick above
 Af = np.array([[ 1,      0,        0],
                [K1, 1 - K1, K1 * σ_y],
-               [ 0,      0,        0]])
+               [ 0,      0,        0]],dtype=object)
 Cf = np.array([[σ_x,        0],
                [  0, K1 * σ_y],
-               [  0,        1]])
+               [  0,        1]],
+               dtype=object)
 Gf = np.array([[1,  0, σ_y],
                [1, -1, σ_y]])
 

--- a/lectures/orth_proj.md
+++ b/lectures/orth_proj.md
@@ -684,19 +684,56 @@ Numerical routines would in this case use the alternative form $R \hat \beta = Q
 
 ## Exercises
 
-### Exercise 1
+```{exercise-start}
+:label: ex1
+```
 
 Show that, for any linear subspace $S \subset \mathbb R^n$,  $S \cap S^{\perp} = \{0\}$.
 
-### Exercise 2
+```{exercise-end}
+```
 
+```{solution-start} ex1
+:class: dropdown
+```
+If $x \in S$ and $x \in S^\perp$, then we have in particular
+that $\langle x, x \rangle = 0$, but then $x = 0$.
+
+```{solution-end}
+```
+
+```{exercise-start}
+:label: ex2
+```
 Let $P = X (X' X)^{-1} X'$ and let $M = I - P$.  Show that
 $P$ and $M$ are both idempotent and symmetric.  Can you give any
 intuition as to why they should be idempotent?
 
-### Exercise 3
+```{exercise-end}
+```
+
+```{solution-start} ex2
+:class: dropdown
+```
+
+Symmetry and idempotence of $M$ and $P$ can be established
+using standard rules for matrix algebra. The intuition behind
+idempotence of $M$ and $P$ is that both are orthogonal
+projections. After a point is projected into a given subspace, applying
+the projection again makes no difference (A point inside the subspace
+is not shifted by orthogonal projection onto that space because it is
+already the closest point in the subspace to itself).
+
+```{solution-end}
+```
+
+
+```{exercise-start}
+:label: ex3
+```
 
 Using Gram-Schmidt orthogonalization, produce a linear projection of $y$ onto the column space of $X$ and verify this using the projection matrix $P := X (X' X)^{-1} X'$ and also using QR decomposition, where:
+
 
 $$
 y :=
@@ -723,24 +760,14 @@ X :=
 \right)
 $$
 
-## Solutions
 
-### Exercise 1
+```{exercise-end}
+```
 
-If $x \in S$ and $x \in S^\perp$, then we have in particular
-that $\langle x, x \rangle = 0$, but then $x = 0$.
 
-### Exercise 2
-
-Symmetry and idempotence of $M$ and $P$ can be established
-using standard rules for matrix algebra. The intuition behind
-idempotence of $M$ and $P$ is that both are orthogonal
-projections. After a point is projected into a given subspace, applying
-the projection again makes no difference. (A point inside the subspace
-is not shifted by orthogonal projection onto that space because it is
-already the closest point in the subspace to itself.).
-
-### Exercise 3
+```{solution-start} ex3
+:class: dropdown
+```
 
 Here's a function that computes the orthonormal vectors using the GS
 algorithm given in the lecture
@@ -831,4 +858,9 @@ Py3
 ```
 
 Again, we obtain the same answer.
+
+```{solution-end}
+```
+
+
 

--- a/lectures/orth_proj.md
+++ b/lectures/orth_proj.md
@@ -685,7 +685,7 @@ Numerical routines would in this case use the alternative form $R \hat \beta = Q
 ## Exercises
 
 ```{exercise-start}
-:label: ex1
+:label: op_ex1
 ```
 
 Show that, for any linear subspace $S \subset \mathbb R^n$,  $S \cap S^{\perp} = \{0\}$.
@@ -693,7 +693,7 @@ Show that, for any linear subspace $S \subset \mathbb R^n$,  $S \cap S^{\perp} =
 ```{exercise-end}
 ```
 
-```{solution-start} ex1
+```{solution-start} op_ex1
 :class: dropdown
 ```
 If $x \in S$ and $x \in S^\perp$, then we have in particular
@@ -703,7 +703,7 @@ that $\langle x, x \rangle = 0$, but then $x = 0$.
 ```
 
 ```{exercise-start}
-:label: ex2
+:label: op_ex2
 ```
 Let $P = X (X' X)^{-1} X'$ and let $M = I - P$.  Show that
 $P$ and $M$ are both idempotent and symmetric.  Can you give any
@@ -712,7 +712,7 @@ intuition as to why they should be idempotent?
 ```{exercise-end}
 ```
 
-```{solution-start} ex2
+```{solution-start} op_ex2
 :class: dropdown
 ```
 
@@ -729,7 +729,7 @@ already the closest point in the subspace to itself).
 
 
 ```{exercise-start}
-:label: ex3
+:label: op_ex3
 ```
 
 Using Gram-Schmidt orthogonalization, produce a linear projection of $y$ onto the column space of $X$ and verify this using the projection matrix $P := X (X' X)^{-1} X'$ and also using QR decomposition, where:
@@ -765,7 +765,7 @@ $$
 ```
 
 
-```{solution-start} ex3
+```{solution-start} op_ex3
 :class: dropdown
 ```
 


### PR DESCRIPTION
Hi @jstac and @mmcky,

I have migrated the first part of the lecture to use sphinx-exercise for the first section: Tools and Techniques.

Here is a summary of places to look at when reviewing this PR: 

1. I changed the _config.yml to enable spinx-exercise and drop-down solutions;
2. In lecture [4. Discrete State Dynamic Programming](https://63077285fc58d3007638c3a0--wonderful-lalande-528d1c.netlify.app/discrete_dp.html#id11), I think the exercise in it is more like a worked example rather than for students to practice themself. Thus, I did not change the style of this exercise. Please kindly let me know if you think it should also be migrated to sphinx-exercise (I think sphinx-exercise does not support adding sections within it as well);
3. A warning and a potential typo were fixed. Please see the following comments for details.

Could you please kindly review whether these changes meet your expectation? If it looks good to you, I will use these as a template for further migration. 

Many thanks.

