### PR TITLE
ENH: Enable chtml for better mathjax math rendering

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -91,7 +91,7 @@ sphinx:
           "fF": "\\mathcal{F}"
           "gG": "\\mathcal{G}"
           "hH": "\\mathcal{H}"
-    mathjax_path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-svg.js
+    mathjax_path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
     rediraffe_redirects:
       index_toc.md: intro.md
     tojupyter_static_file_path: ["source/_static", "_static"]

--- a/lectures/knowing_forecasts_of_others.md
+++ b/lectures/knowing_forecasts_of_others.md
@@ -1614,16 +1614,16 @@ appropriate orders of the autoregressive and moving average pieces of
 the equilibrium representation.
 
 By working in the frequency
-domain [[Kas00](https://python-advanced.quantecon.org/zreferences.html#id24)] showed how to discover the appropriate
+domain [[Kas00](kasa)] showed how to discover the appropriate
 orders of the autoregressive and moving average parts, and also how to
 compute an equilibrium.
 
-The  [[PS05](https://python-advanced.quantecon.org/zreferences.html#id22)] recursive computational method, which stays in the time domain, also
+The  [[PS05](Pearlman_Sargent2005)] recursive computational method, which stays in the time domain, also
 discovered appropriate orders of the autoregressive and moving
 average pieces.
 
 In addition, by displaying equilibrium representations
-in the form of [[PCL86](https://python-advanced.quantecon.org/zreferences.html#id23)], [[PS05](https://python-advanced.quantecon.org/zreferences.html#id22)]
+in the form of [[PCL86](PCL)], [[PS05](Pearlman_Sargent2005)]
 showed how the moving average piece is linked to the innovation process
 of the hidden persistent component of the demand shock.
 
@@ -1632,25 +1632,25 @@ innovation process is the additional state variable contributed by the
 problem of extracting a signal from equilibrium prices that decision
 makers face in Townsend’s model.
 
-[^footnote0]: [PS05](zreferences.html#id22) verified this assertion using a different tactic, namely, by constructing
+[^footnote0]: [PS05](Pearlman_Sargent2005) verified this assertion using a different tactic, namely, by constructing
 analytic formulas for an equilibrium under the incomplete
 information structure and confirming that they match the pooling equilibrium formulas derived here.
 
-[^footnote3]: See [[Sar87](zreferences.html#id197)], especially
+[^footnote3]: See [Sar87](Sargent1987), especially
 chapters IX and XIV, for  principles  that guide solving some roots backwards and others forwards.
 
-[^footnote4]: As noted by [[Sar87](zreferences.html#id197)], this difference equation is the Euler equation for
+[^footnote4]: As noted by [Sar87](Sargent1987), this difference equation is the Euler equation for
 a planning problem   that maximizes the discounted sum of consumer plus
 producer surplus.
 
-[^footnote5]: [[PS05](zreferences.html#id22)] verify the same claim by applying   machinery of  [[PCL86](zreferences.html#id23)].
+[^footnote5]: [PS05](Pearlman_Sargent2005) verify the same claim by applying   machinery of  [PCL86](PCL).
 
-[^footnote1]: See [[AHMS96](zreferences.html#id135)] for an account of invariant subspace methods.
+[^footnote1]: See [AHMS96](ahms) for an account of invariant subspace methods.
 
-[^footnote2]: See [[AMS02](zreferences.html#id28)] for a discussion
+[^footnote2]: See [AMS02](ams) for a discussion
 of  information assumptions needed to create a situation
 in which higher order beliefs appear in equilibrium decision rules.  A way
-to read our findings in light of [[AMS02](zreferences.html#id28)] is that, relative
+to read our findings in light of [AMS02](ams) is that, relative
 to the number of signals agents observe,  Townsend’s
 section 8 model  has too few  random shocks  to get higher order beliefs to
 play a role.


### PR DESCRIPTION
This is hopefully now well support by `sphinx` and `mathjax`.

The `chtml` option renders math better in the `html` output