### PR TITLE
ENH: Upgrade to jupyter-book==0.15.1 + associated packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
           python-version: 3.9
           environment-file: environment.yml
           activate-environment: quantecon
+      - name: Install docutils==0.17.1
+        run: |
+          pip install docutils==0.17.1
       - name: Install latex dependencies
         run: |
           sudo apt-get -qq update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,6 @@ jobs:
           python-version: 3.9
           environment-file: environment.yml
           activate-environment: quantecon
-      - name: Install docutils==0.17.1
-        run: |
-          pip install docutils==0.17.1
       - name: Install latex dependencies
         run: |
           sudo apt-get -qq update
@@ -37,13 +34,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: cache.yml
-          branch: main
-          name: build-cache
-          path: _build
+      # - name: Download "build" folder (cache)
+      #   uses: dawidd6/action-download-artifact@v2
+      #   with:
+      #     workflow: cache.yml
+      #     branch: main
+      #     name: build-cache
+      #     path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build PDF from LaTeX
         shell: bash -l {0}

--- a/environment.yml
+++ b/environment.yml
@@ -6,20 +6,11 @@ dependencies:
   - anaconda=2022.05
   - pip
   - pip:
-    - jupyter-book==0.12.3
-    - quantecon-book-theme==0.3.1
-    - sphinx-tojupyter==0.2.1
+    - jupyter-book==0.15.1
+    - quantecon-book-theme==0.4.1
+    - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
-    - sphinx-exercise==0.4.0
+    - sphinx-exercise==0.4.1
     - ghp-import==1.1.0
     - sphinxcontrib-youtube==1.1.0
     - sphinx-togglebutton==0.3.1
-    # Sandpit Requirements
-    - quantecon
-    - libsass
-    - array-to-latex
-    - PuLP
-    - cvxpy
-    - cvxopt
-    - cylp
-    - prettytable

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -52,6 +52,7 @@ sphinx:
        ['jupyter', 'image/jpeg', 70],
        ['jupyter', 'text/markdown', 80],
        ['jupyter', 'text/plain', 90],
+       ['linkcheck', 'text/plain', 10],
      ]
     html_favicon: _static/lectures-favicon.ico
     html_theme: quantecon_book_theme

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -33,27 +33,26 @@ latex:
 sphinx:
   extra_extensions: [sphinx_multitoc_numbering, sphinxext.rediraffe, sphinx_tojupyter, sphinx_exercise, sphinx_togglebutton]
   config:
-    nb_render_priority:
-      html:
-      - "application/vnd.jupyter.widget-view+json"
-      - "application/javascript"
-      - "text/html"
-      - "text/latex"
-      - "image/svg+xml"
-      - "image/png"
-      - "image/jpeg"
-      - "text/markdown"
-      - "text/plain"
-      jupyter:
-      - "application/vnd.jupyter.widget-view+json"
-      - "application/javascript"
-      - "text/html"
-      - "text/latex"
-      - "image/svg+xml"
-      - "image/png"
-      - "image/jpeg"
-      - "text/markdown"
-      - "text/plain"
+    nb_mime_priority_overrides: [
+       ['html', 'application/vnd.jupyter.widget-view+json', 10],
+       ['html', 'application/javascript', 20],
+       ['html', 'text/html', 30],
+       ['html', 'text/latex', 40],
+       ['html', 'image/svg+xml', 50],
+       ['html', 'image/png', 60],
+       ['html', 'image/jpeg', 70],
+       ['html', 'text/markdown', 80],
+       ['html', 'text/plain', 90],
+       ['jupyter', 'application/vnd.jupyter.widget-view+json', 10],
+       ['jupyter', 'application/javascript', 20],
+       ['jupyter', 'text/html', 30],
+       ['jupyter', 'text/latex', 40],
+       ['jupyter', 'image/svg+xml', 50],
+       ['jupyter', 'image/png', 60],
+       ['jupyter', 'image/jpeg', 70],
+       ['jupyter', 'text/markdown', 80],
+       ['jupyter', 'text/plain', 90],
+     ]
     html_favicon: _static/lectures-favicon.ico
     html_theme: quantecon_book_theme
     html_static_path: ['_static']
@@ -91,7 +90,7 @@ sphinx:
           "fF": "\\mathcal{F}"
           "gG": "\\mathcal{G}"
           "hH": "\\mathcal{H}"
-    mathjax_path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-svg.js
+    mathjax_path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
     rediraffe_redirects:
       index_toc.md: intro.md
     tojupyter_static_file_path: ["source/_static", "_static"]

--- a/lectures/five_preferences.md
+++ b/lectures/five_preferences.md
@@ -236,7 +236,7 @@ for i in range(π_hat_0_vals.size):  # Loop over all possible values for `π_hat
 ```{code-cell} ipython3
 ---
 tags: [hide-input]
-render:
+mystnb:
   figure:
     caption: |
       Figure 1

--- a/lectures/knowing_forecasts_of_others.md
+++ b/lectures/knowing_forecasts_of_others.md
@@ -1556,25 +1556,23 @@ Townsend argued that the more manageable model  could do a good job of
 approximating the intractable model in which the Markov component of the demand shock remains unobserved
 for ever.
 
-By applying technical machinery of [[PCL86](https://python-advanced.quantecon.org/zreferences.html#id23)],
-[[PS05](https://python-advanced.quantecon.org/zreferences.html#id22)] showed that there is a recursive
+By applying technical machinery of {cite}`PCL`, {cite}`Pearlman_Sargent2005` showed that there is a recursive
 representation of the equilibrium of the perpetually and symmetrically
 uninformed model that Townsend wanted to solve
-[[Tow83](https://python-advanced.quantecon.org/zreferences.html#id25)].
+{cite}`townsend`.
 
-A reader of [[PS05](https://python-advanced.quantecon.org/zreferences.html#id22)] will notice that their representation of the equilibrium of
+A reader of {cite}`Pearlman_Sargent2005` will notice that their representation of the equilibrium of
 Townsend’s model exactly matches that of the  **pooling equilibrium** presented here.
 
 We have structured  our notation in  this lecture to faciliate comparison of the **pooling equilibrium**
-constructed here with the equilibrium of Townsend’s model reported in  [[PS05](https://python-advanced.quantecon.org/zreferences.html#id22)].
+constructed here with the equilibrium of Townsend’s model reported in {cite}`Pearlman_Sargent2005`.
 
-The computational method of [[PS05](https://python-advanced.quantecon.org/zreferences.html#id22)] is recursive:
+The computational method of {cite}`Pearlman_Sargent2005` is recursive:
 it enlists the Kalman filter and invariant subspace methods for
 solving systems of Euler
 equations [^footnote1] .
 
-As {cite}`singleton87`,
-[[Kas00](https://python-advanced.quantecon.org/zreferences.html#id24)], and {cite}`sargent91_equilibrium` also
+As {cite}`singleton87`, {cite}`kasa`, and {cite}`sargent91_equilibrium` also
 found, the equilibrium is fully revealing: observed prices tell
 participants in industry $ i $ all of the information held by
 participants in market $ -i $ ($ -i $ means not $ i $).
@@ -1598,7 +1596,7 @@ those forecasts are the same as their own, they know them.
 Sargent {cite}`sargent91_equilibrium` proposed a way to compute an equilibrium
 without making Townsend’s approximation.
 
-Extending the reasoning of [[Mut60](https://python-advanced.quantecon.org/zreferences.html#id110)], Sargent noticed that it is possible to
+Extending the reasoning of {cite}`Muth1960`, Sargent noticed that it is possible to
 summarize the relevant history with a low dimensional object, namely, a
 small number of current and lagged forecasting errors.
 
@@ -1614,16 +1612,16 @@ appropriate orders of the autoregressive and moving average pieces of
 the equilibrium representation.
 
 By working in the frequency
-domain [[Kas00](https://python-advanced.quantecon.org/zreferences.html#id24)] showed how to discover the appropriate
+domain {cite}`kasa` showed how to discover the appropriate
 orders of the autoregressive and moving average parts, and also how to
 compute an equilibrium.
 
-The  [[PS05](https://python-advanced.quantecon.org/zreferences.html#id22)] recursive computational method, which stays in the time domain, also
+The  {cite}`Pearlman_Sargent2005` recursive computational method, which stays in the time domain, also
 discovered appropriate orders of the autoregressive and moving
 average pieces.
 
 In addition, by displaying equilibrium representations
-in the form of [[PCL86](https://python-advanced.quantecon.org/zreferences.html#id23)], [[PS05](https://python-advanced.quantecon.org/zreferences.html#id22)]
+in the form of {cite}`PCL`, {cite}`Pearlman_Sargent2005`
 showed how the moving average piece is linked to the innovation process
 of the hidden persistent component of the demand shock.
 
@@ -1632,25 +1630,25 @@ innovation process is the additional state variable contributed by the
 problem of extracting a signal from equilibrium prices that decision
 makers face in Townsend’s model.
 
-[^footnote0]: [PS05](zreferences.html#id22) verified this assertion using a different tactic, namely, by constructing
+[^footnote0]: {cite}`Pearlman_Sargent2005` verified this assertion using a different tactic, namely, by constructing
 analytic formulas for an equilibrium under the incomplete
 information structure and confirming that they match the pooling equilibrium formulas derived here.
 
-[^footnote3]: See [[Sar87](zreferences.html#id197)], especially
+[^footnote3]: See {cite}`Sargent1987`, especially
 chapters IX and XIV, for  principles  that guide solving some roots backwards and others forwards.
 
-[^footnote4]: As noted by [[Sar87](zreferences.html#id197)], this difference equation is the Euler equation for
+[^footnote4]: As noted by {cite}`Sargent1987`, this difference equation is the Euler equation for
 a planning problem   that maximizes the discounted sum of consumer plus
 producer surplus.
 
-[^footnote5]: [[PS05](zreferences.html#id22)] verify the same claim by applying   machinery of  [[PCL86](zreferences.html#id23)].
+[^footnote5]: [PS05](Pearlman_Sargent2005) verify the same claim by applying   machinery of  {cite}`PCL`.
 
-[^footnote1]: See [[AHMS96](zreferences.html#id135)] for an account of invariant subspace methods.
+[^footnote1]: See [AHMS96](ahms) for an account of invariant subspace methods.
 
-[^footnote2]: See [[AMS02](zreferences.html#id28)] for a discussion
+[^footnote2]: See [AMS02](ams) for a discussion
 of  information assumptions needed to create a situation
 in which higher order beliefs appear in equilibrium decision rules.  A way
-to read our findings in light of [[AMS02](zreferences.html#id28)] is that, relative
+to read our findings in light of [AMS02](ams) is that, relative
 to the number of signals agents observe,  Townsend’s
 section 8 model  has too few  random shocks  to get higher order beliefs to
 play a role.


### PR DESCRIPTION
This PR upgrades to `jupyter-book==0.15.1` + associated packages