### PR TITLE
MAINT: upgrade quantecon-book-theme and author information

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip:
     - jupyter-book==0.15.1
     - docutils==0.17.1
-    - quantecon-book-theme==0.6.0
+    - quantecon-book-theme==0.7.1
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==0.4.1

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -74,6 +74,11 @@ sphinx:
     html_theme: quantecon_book_theme
     html_static_path: ['_static']
     html_theme_options:
+      authors:
+        - name: Thomas J. Sargent
+          url: http://www.tomsargent.com/
+        - name: John Stachurski
+          url: https://johnstachurski.net/
       header_organisation_url: https://quantecon.org
       header_organisation: QuantEcon
       repository_url: https://github.com/QuantEcon/lecture-python-advanced.myst

--- a/lectures/intro.md
+++ b/lectures/intro.md
@@ -11,8 +11,7 @@ kernelspec:
 
 # Advanced Quantitative Economics with Python
 
-This website presents a set of advanced lectures on quantitative economic modeling, designed and written by
-[Thomas J. Sargent](http://www.tomsargent.com/) and [John Stachurski](http://johnstachurski.net/).
+This website presents a set of advanced lectures on quantitative economic modeling.
 
 ```{tableofcontents}
 ```


### PR DESCRIPTION
This PR

- [x] upgrades to `quantecon-book-theme==0.7.1`
- [x] updates author information for improved author support