### PR TITLE
MAINT: remove %matplotlib inline and contents directive

### DIFF
--- a/lectures/BCG_complete_mkts.md
+++ b/lectures/BCG_complete_mkts.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Irrelevance of Capital Structures with Complete Markets
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython
@@ -872,7 +868,6 @@ import matplotlib.pyplot as plt
 from scipy.stats import norm
 from numba import njit, prange
 from quantecon.optimize import root_finding
-%matplotlib inline
 ```
 
 ```{code-cell} python3

--- a/lectures/BCG_incomplete_mkts.md
+++ b/lectures/BCG_incomplete_mkts.md
@@ -22,10 +22,6 @@ kernelspec:
 
 # Equilibrium Capital Structures with Incomplete Markets
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython3

--- a/lectures/additive_functionals.md
+++ b/lectures/additive_functionals.md
@@ -25,10 +25,6 @@ kernelspec:
 ```{index} single: Models; Additive functionals
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython3
@@ -78,7 +74,6 @@ import numpy as np
 import scipy.linalg as la
 import quantecon as qe
 import matplotlib.pyplot as plt
-%matplotlib inline
 from scipy.stats import norm, lognorm
 ```
 

--- a/lectures/amss.md
+++ b/lectures/amss.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Optimal Taxation without State-Contingent Debt
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/amss2.md
+++ b/lectures/amss2.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Fluctuating Interest Rates Deliver Fiscal Insurance
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython
@@ -89,7 +85,6 @@ Let's start with some imports:
 
 ```{code-cell} ipython
 import matplotlib.pyplot as plt
-%matplotlib inline
 from scipy.optimize import fsolve, fmin
 ```
 

--- a/lectures/amss3.md
+++ b/lectures/amss3.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Fiscal Risk and Government Debt
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython
@@ -74,7 +70,6 @@ Let's start with some imports:
 
 ```{code-cell} ipython
 import matplotlib.pyplot as plt
-%matplotlib inline
 from scipy.optimize import minimize
 ```
 

--- a/lectures/arellano.md
+++ b/lectures/arellano.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Default Risk and Income Fluctuations
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} python
@@ -78,9 +74,7 @@ Let's start with some imports:
 import matplotlib.pyplot as plt
 import numpy as np
 import quantecon as qe
-
 from numba import njit, prange
-%matplotlib inline
 ```
 
 ## Structure

--- a/lectures/arma.md
+++ b/lectures/arma.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # {index}`Covariance Stationary Processes <single: Covariance Stationary Processes>`
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython
@@ -95,7 +91,6 @@ Let's start with some imports:
 ```{code-cell} ipython
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
 import quantecon as qe
 ```
 

--- a/lectures/asset_pricing_lph.md
+++ b/lectures/asset_pricing_lph.md
@@ -17,10 +17,6 @@ kernelspec:
 ```{index} single: Elementary Asset Pricing
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 This lecture is about  some implications of  asset-pricing theories that are based on the equation
@@ -356,7 +352,6 @@ In drawing a frontier, we'll set $\sigma(m) = .25$ and $E m = .99$, values rough
 ```{code-cell} ipython3
 import matplotlib.pyplot as plt
 import numpy as np
-%matplotlib inline
 
 # Define the function to plot
 def y(x, alpha, beta):
@@ -590,7 +585,6 @@ Let's start with some imports.
 import numpy as np
 import statsmodels.api as sm
 import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 Lots of our calculations will involve computing population and sample OLS regressions.

--- a/lectures/black_litterman.md
+++ b/lectures/black_litterman.md
@@ -23,10 +23,6 @@ kernelspec:
 
 # Two Modifications of Mean-Variance Portfolio Theory
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 This lecture describes extensions to the classical mean-variance portfolio theory summarized in our lecture [Elementary Asset Pricing Theory](https://python-advanced.quantecon.org/asset_pricing_lph.html).
@@ -87,7 +83,6 @@ Let's start with some imports:
 import numpy as np
 import scipy.stats as stat
 import matplotlib.pyplot as plt
-%matplotlib inline
 from ipywidgets import interact, FloatSlider
 ```
 

--- a/lectures/calvo.md
+++ b/lectures/calvo.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Models; Additive functionals
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython
@@ -81,7 +77,6 @@ We'll start with some imports:
 import numpy as np
 from quantecon import LQ
 import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 ## The Model

--- a/lectures/cattle_cycles.md
+++ b/lectures/cattle_cycles.md
@@ -23,10 +23,6 @@ kernelspec:
 
 # Cattle Cycles
 
-```{contents} Contents
-:depth: 2
-```
-
 This is another member of a suite of lectures that use the quantecon DLE class to instantiate models within the
 {cite}`HS2013` class of models described in detail in {doc}`Recursive Models of Dynamic Linear Economies <hs_recursive_models>`.
 
@@ -53,7 +49,6 @@ import matplotlib.pyplot as plt
 from collections import namedtuple
 from quantecon import DLE
 from math import sqrt
-%matplotlib inline
 ```
 
 ## The Model

--- a/lectures/chang_credible.md
+++ b/lectures/chang_credible.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Credible Government Policies in a Model of Chang
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython
@@ -88,7 +84,6 @@ Let's start with some standard imports:
 import numpy as np
 import polytope
 import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 ## The Setting

--- a/lectures/chang_ramsey.md
+++ b/lectures/chang_ramsey.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Competitive Equilibria of a Model of Chang
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython
@@ -76,7 +72,6 @@ We'll start with some standard imports:
 import numpy as np
 import polytope
 import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 ### The Setting

--- a/lectures/classical_filtering.md
+++ b/lectures/classical_filtering.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Classical Prediction and Filtering With Linear Algebra
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 This is a sequel to the earlier lecture {doc}`Classical Control with Linear Algebra <lu_tricks>`.

--- a/lectures/coase.md
+++ b/lectures/coase.md
@@ -22,10 +22,6 @@ kernelspec:
 
 # {index}`Coase's Theory of the Firm <single: Coase's Theory of the Firm>`
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 In 1937, Ronald Coase wrote a brilliant essay on the nature of the firm {cite}`coase1937nature`.

--- a/lectures/cons_news.md
+++ b/lectures/cons_news.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Information and Consumption Smoothing
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture employs the following libraries:
 
 ```{code-cell} ipython
@@ -607,7 +603,6 @@ As usual, we start by importing packages.
 import numpy as np
 import quantecon as qe
 import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 ```{code-cell} python3

--- a/lectures/discrete_dp.md
+++ b/lectures/discrete_dp.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # {index}`Discrete State Dynamic Programming <single: Discrete State Dynamic Programming>`
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython
@@ -66,7 +62,6 @@ Let's start with some imports:
 ```{code-cell} ipython
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
 import quantecon as qe
 import scipy.sparse as sparse
 from quantecon import compute_fixed_point

--- a/lectures/dyn_stack.md
+++ b/lectures/dyn_stack.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Stackelberg Plans
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython
@@ -57,7 +53,6 @@ import numpy.linalg as la
 import quantecon as qe
 from quantecon import LQ
 import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 ## Duopoly

--- a/lectures/estspec.md
+++ b/lectures/estspec.md
@@ -18,13 +18,9 @@ kernelspec:
 </div>
 ```
 
-# Estimation of {index}`Spectra <single: Spectra>`
+# Estimation of Spectra
 
 ```{index} single: Spectra; Estimation
-```
-
-```{contents} Contents
-:depth: 2
 ```
 
 In addition to what's in Anaconda, this lecture will need the following libraries:
@@ -59,7 +55,6 @@ Let's start with some standard imports:
 ```{code-cell} ipython
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
 from quantecon import ARMA, periodogram, ar_periodogram
 ```
 

--- a/lectures/five_preferences.md
+++ b/lectures/five_preferences.md
@@ -36,8 +36,8 @@ The preference orderings are
 This labeling  scheme is taken from {cite}`HansenSargent2001`.
 
 
-Constraint and multiplier preferences express  aversion to not knowing a unique probabiity distribution
-that desribes random outcomes.
+Constraint and multiplier preferences express  aversion to not knowing a unique probability distribution
+that describes random outcomes.
 
 Expected utility, risk-sensitive, and ex post Bayesian expected utility preferences all attribute a unique known
 probability distribution to a decision maker.
@@ -59,7 +59,6 @@ We begin with some that we'll use to create some graphs.
 import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt
-plt.rcParams["figure.figsize"] = (11, 5)
 from matplotlib import rc, cm
 from mpl_toolkits.mplot3d import Axes3D
 from scipy import optimize, stats
@@ -73,7 +72,6 @@ from numba import njit
 :tags: [hide-input]
 
 # Plotting parameters
-%matplotlib inline
 %config InlineBackend.figure_format='retina'
 
 plt.rc('text', usetex=True)

--- a/lectures/growth_in_dles.md
+++ b/lectures/growth_in_dles.md
@@ -23,10 +23,6 @@ kernelspec:
 
 # Growth in Dynamic Linear Economies
 
-```{contents} Contents
-:depth: 2
-```
-
 This is another member of a suite of lectures that use the quantecon DLE class to instantiate models within the
 {cite}`HS2013` class of models described in detail in {doc}`Recursive Models of Dynamic Linear Economies <hs_recursive_models>`.
 
@@ -52,7 +48,6 @@ We require the following imports
 ```{code-cell} ipython
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
 from quantecon import DLE
 ```
 

--- a/lectures/hs_invertibility_example.md
+++ b/lectures/hs_invertibility_example.md
@@ -23,10 +23,6 @@ kernelspec:
 
 # Shock Non Invertibility
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 This is another member of a suite of lectures that use the quantecon DLE class to instantiate models within the
@@ -49,7 +45,6 @@ import quantecon as qe
 import matplotlib.pyplot as plt
 from quantecon import DLE
 from math import sqrt
-%matplotlib inline
 ```
 
 This lecture describes  an early contribution to what is now often called

--- a/lectures/hs_recursive_models.md
+++ b/lectures/hs_recursive_models.md
@@ -23,10 +23,6 @@ kernelspec:
 
 # Recursive Models of Dynamic Linear Economies
 
-```{contents} Contents
-:depth: 2
-```
-
 ```{epigraph}
 "Mathematics is the art of giving the same name to different things" -- Henri Poincare
 ```

--- a/lectures/irfs_in_hall_model.md
+++ b/lectures/irfs_in_hall_model.md
@@ -23,10 +23,6 @@ kernelspec:
 
 # IRFs in Hall Models
 
-```{contents} Contents
-:depth: 2
-```
-
 This is another member of a suite of lectures that use the quantecon DLE class to instantiate models within the
 {cite}`HS2013` class of models described in detail in {doc}`Recursive Models of Dynamic Linear Economies <hs_recursive_models>`.
 
@@ -44,7 +40,6 @@ We'll make these imports:
 ```{code-cell} ipython
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
 from quantecon import DLE
 ```
 

--- a/lectures/knowing_forecasts_of_others.md
+++ b/lectures/knowing_forecasts_of_others.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Knowing the Forecasts of Others
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/lqramsey.md
+++ b/lectures/lqramsey.md
@@ -18,13 +18,9 @@ kernelspec:
 </div>
 ```
 
-# {index}`Optimal Taxation in an LQ Economy <single: Optimal Taxation in an LQ Economy>`
+# Optimal Taxation in an LQ Economy
 
 ```{index} single: Ramsey Problem; Optimal Taxation
-```
-
-```{contents} Contents
-:depth: 2
 ```
 
 In addition to what's in Anaconda, this lecture will need the following libraries:
@@ -81,7 +77,6 @@ We'll need the following imports:
 import sys
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
 from numpy import sqrt, eye, zeros, cumsum
 from numpy.random import randn
 import scipy.linalg

--- a/lectures/lu_tricks.md
+++ b/lectures/lu_tricks.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Classical Control with Linear Algebra
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 In an earlier lecture [Linear Quadratic Dynamic Programming Problems](https://python-intro.quantecon.org/lqcontrol.html), we have studied how to solve a special
@@ -59,7 +55,6 @@ Let's start with some standard imports:
 ```{code-cell} ipython
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 ### References

--- a/lectures/lucas_asset_pricing_dles.md
+++ b/lectures/lucas_asset_pricing_dles.md
@@ -23,10 +23,6 @@ kernelspec:
 
 # Lucas Asset Pricing Using DLE
 
-```{contents} Contents
-:depth: 2
-```
-
 This is one of a suite of lectures that use the quantecon DLE class to instantiate models within the
 {cite}`HS2013` class of models described in detail in {doc}`Recursive Models of Dynamic Linear Economies <hs_recursive_models>`.
 
@@ -56,7 +52,6 @@ We'll also need the following imports
 import numpy as np
 import matplotlib.pyplot as plt
 from quantecon import DLE
-%matplotlib inline
 ```
 
 We use a linear-quadratic version of an economy that Lucas (1978) {cite}`Lucas1978` used

--- a/lectures/lucas_model.md
+++ b/lectures/lucas_model.md
@@ -25,10 +25,6 @@ kernelspec:
 ```{index} single: Models; Lucas Asset Pricing
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 As stated in an [earlier lecture](https://python-intro.quantecon.org/markov_asset.html), an asset is a claim on a stream of prospective payments.

--- a/lectures/markov_jump_lq.md
+++ b/lectures/markov_jump_lq.md
@@ -23,10 +23,6 @@ kernelspec:
 
 # Markov Jump Linear Quadratic Dynamic Programming
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython
@@ -253,8 +249,6 @@ import numpy as np
 import quantecon as qe
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
-
-%matplotlib inline
 ```
 
 ```{code-cell} python3

--- a/lectures/matsuyama.md
+++ b/lectures/matsuyama.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Globalization and Cycles
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 In this lecture, we review the paper [Globalization and Synchronization of Innovation Cycles](http://www.centreformacroeconomics.ac.uk/Discussion-Papers/2015/CFMDP2015-27-Paper.pdf) by [Kiminori Matsuyama](http://faculty.wcas.northwestern.edu/~kmatsu/), [Laura Gardini](http://www.mdef.it/index.php?id=32) and [Iryna Sushko](http://irynasushko.altervista.org/).
@@ -45,7 +41,6 @@ Let's start with some imports:
 ```{code-cell} ipython
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
 from numba import jit
 from ipywidgets import interact
 ```

--- a/lectures/muth_kalman.md
+++ b/lectures/muth_kalman.md
@@ -23,10 +23,6 @@ kernelspec:
 
 # Reverse Engineering a la Muth
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture uses the quantecon library.
 
 ```{code-cell} ipython
@@ -40,7 +36,6 @@ We'll also need the following imports:
 
 ```{code-cell} ipython
 import matplotlib.pyplot as plt
-%matplotlib inline
 import numpy as np
 
 from quantecon import Kalman

--- a/lectures/opt_tax_recur.md
+++ b/lectures/opt_tax_recur.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Optimal Taxation with State-Contingent Debt
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/orth_proj.md
+++ b/lectures/orth_proj.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Orthogonal Projection
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 Orthogonal projection is a cornerstone of vector space methods, with many diverse applications.

--- a/lectures/permanent_income_dles.md
+++ b/lectures/permanent_income_dles.md
@@ -23,10 +23,6 @@ kernelspec:
 
 # Permanent Income Model using the DLE Class
 
-```{contents} Contents
-:depth: 2
-```
-
 This lecture is part of a suite of lectures that use the quantecon DLE class to instantiate models within the
 {cite}`HS2013` class of models described in detail in {doc}`Recursive Models of Dynamic Linear Economies <hs_recursive_models>`.
 
@@ -56,7 +52,6 @@ We'll also require the following imports
 ```{code-cell} ipython
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
 from quantecon import DLE
 
 np.set_printoptions(suppress=True, precision=4)

--- a/lectures/rob_markov_perf.md
+++ b/lectures/rob_markov_perf.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Robust Markov Perfect Equilibrium
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython
@@ -58,7 +54,6 @@ import numpy as np
 import quantecon as qe
 from scipy.linalg import solve
 import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 ### Basic Setup

--- a/lectures/robustness.md
+++ b/lectures/robustness.md
@@ -25,10 +25,6 @@ kernelspec:
 ```{index} single: Robustness
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython3
@@ -85,7 +81,6 @@ import pandas as pd
 import numpy as np
 from scipy.linalg import eig
 import matplotlib.pyplot as plt
-%matplotlib inline
 import quantecon as qe
 ```
 

--- a/lectures/rosen_schooling_model.md
+++ b/lectures/rosen_schooling_model.md
@@ -23,10 +23,6 @@ kernelspec:
 
 # Rosen Schooling Model
 
-```{contents} Contents
-:depth: 2
-```
-
 This lecture is yet another part of a suite of lectures that use the quantecon DLE class to instantiate models within the
 {cite}`HS2013` class of models described in detail in {doc}`Recursive Models of Dynamic Linear Economies <hs_recursive_models>`.
 
@@ -46,7 +42,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 from collections import namedtuple
 from quantecon import DLE
-%matplotlib inline
 ```
 
 ## A One-Occupation Model

--- a/lectures/smoothing.md
+++ b/lectures/smoothing.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Consumption; Tax
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture uses the  library:
 
 ```{code-cell} ipython
@@ -83,7 +79,6 @@ Let's start with some imports:
 import numpy as np
 import quantecon as qe
 import matplotlib.pyplot as plt
-%matplotlib inline
 import scipy.linalg as la
 ```
 

--- a/lectures/smoothing_tax.md
+++ b/lectures/smoothing_tax.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Smoothing; Tax
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture uses the  library:
 
 ```{code-cell} ipython
@@ -97,7 +93,6 @@ Let's start with some standard imports:
 import numpy as np
 import quantecon as qe
 import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 To exploit the isomorphism between consumption-smoothing and tax-smoothing models, we  simply use code from {doc}`Consumption Smoothing with Complete and Incomplete Markets <smoothing>`

--- a/lectures/stationary_densities.md
+++ b/lectures/stationary_densities.md
@@ -18,13 +18,9 @@ kernelspec:
 </div>
 ```
 
-# {index}`Continuous State Markov Chains <single: Continuous State Markov Chains>`
+# Continuous State Markov Chains
 
 ```{index} single: Markov Chains; Continuous State
-```
-
-```{contents} Contents
-:depth: 2
 ```
 
 In addition to what's in Anaconda, this lecture will need the following libraries:
@@ -78,7 +74,6 @@ Let's begin with some imports:
 ```{code-cell} ipython
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
 from scipy.stats import lognorm, beta
 from quantecon import LAE
 from scipy.stats import norm, gaussian_kde

--- a/lectures/tax_smoothing_1.md
+++ b/lectures/tax_smoothing_1.md
@@ -23,10 +23,6 @@ kernelspec:
 
 # How to Pay for a War: Part 1
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will deploy quantecon:
 
 ```{code-cell} ipython
@@ -44,7 +40,6 @@ Let's start with some standard imports:
 import quantecon as qe
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 This lecture uses the method of   **Markov jump linear quadratic dynamic programming** that is described in lecture

--- a/lectures/tax_smoothing_2.md
+++ b/lectures/tax_smoothing_2.md
@@ -23,10 +23,6 @@ kernelspec:
 
 # How to Pay for a War: Part 2
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture  deploys the quantecon library:
 
 ```{code-cell} ipython
@@ -79,7 +75,6 @@ Let's start with some standard imports:
 import quantecon as qe
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 ## Two example specifications

--- a/lectures/tax_smoothing_3.md
+++ b/lectures/tax_smoothing_3.md
@@ -23,10 +23,6 @@ kernelspec:
 
 # How to Pay for a War: Part 3
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture deploys the quantecon library:
 
 ```{code-cell} ipython
@@ -62,7 +58,6 @@ Let's start with some standard imports:
 import quantecon as qe
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 ## Roll-Over Risk

--- a/lectures/troubleshooting.md
+++ b/lectures/troubleshooting.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Troubleshooting
 
-```{contents} Contents
-:depth: 2
-```
-
 This page is for readers experiencing errors when running the code from the lectures.
 
 ## Fixing Your Local Environment


### PR DESCRIPTION
This PR addresses https://github.com/QuantEcon/meta/issues/134 and removes `contents` directives to simplify