### PR TITLE
Remove numba pin

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,5 +15,3 @@ dependencies:
     - ghp-import==1.1.0
     - sphinxcontrib-youtube==1.1.0
     - sphinx-togglebutton==0.3.1
-    # Temporary
-    - numba==0.59.1


### PR DESCRIPTION
Fixes #163.

Removed `numba` pin because the issue is fixed in `interpolation.py` in the new release `2.2.7`.