### PR TITLE
MAINT: update jupyter-book==1.0.3 and maintenance tasks

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,11 +1,8 @@
 name: Build Cache [using jupyter-book]
 on:
-  push:
-    branches:
-      - main
   schedule:
-    # run cache monthly to prevent expiration
-    - cron:  '0 0 1 * *'
+    # Execute cache weekly at 3am on Monday
+    - cron:  '0 3 * * 1'
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v7
-        with:
-          workflow: cache.yml
-          branch: main
-          name: build-cache
-          path: _build
+      # - name: Download "build" folder (cache)
+      #   uses: dawidd6/action-download-artifact@v7
+      #   with:
+      #     workflow: cache.yml
+      #     branch: main
+      #     name: build-cache
+      #     path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build PDF from LaTeX
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      # - name: Download "build" folder (cache)
-      #   uses: dawidd6/action-download-artifact@v7
-      #   with:
-      #     workflow: cache.yml
-      #     branch: main
-      #     name: build-cache
-      #     path: _build
+      - name: Download "build" folder (cache)
+        uses: dawidd6/action-download-artifact@v7
+        with:
+          workflow: cache.yml
+          branch: main
+          name: build-cache
+          path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build PDF from LaTeX
         shell: bash -l {0}

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -2,9 +2,6 @@ name: Link Checker [Anaconda, Linux]
 on:
   pull_request:
     types: [opened, reopened]
-  schedule:
-    # UTC 12:00 is early morning in Australia
-    - cron:  '0 12 * * *'
 jobs:
   link-check-linux:
     name: Link Checking (${{ matrix.python-version }}, ${{ matrix.os }})

--- a/environment.yml
+++ b/environment.yml
@@ -6,13 +6,16 @@ dependencies:
   - anaconda=2024.10
   - pip
   - pip:
-    - jupyter-book==0.15.1
-    - docutils==0.17.1
-    - quantecon-book-theme==0.7.2
+    - jupyter-book==1.0.3
+    - quantecon-book-theme==0.7.6
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
-    - sphinx-exercise==0.4.1
+    - sphinx-reredirects==0.1.4
+    - sphinx-exercise==1.0.1
+    - sphinx-proof==0.2.0
     - ghp-import==1.1.0
-    - sphinxcontrib-youtube==1.1.0
-    - sphinx-togglebutton==0.3.1
-    - sphinx-proof
+    - sphinxcontrib-youtube==1.3.0 #Version 1.3.0 is required as quantecon-book-theme is only compatible with sphinx<=5
+    - sphinx-togglebutton==0.3.2
+    # Docker Requirements
+    - pytz
+

--- a/lectures/status.md
+++ b/lectures/status.md
@@ -16,5 +16,19 @@ This table contains the latest execution statistics.
 ```{nb-exec-table}
 ```
 
-These lectures are built on `linux` instances through `github actions` so are
-executed using the following [hardware specifications](https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources)
+(status:machine-details)=
+
+These lectures are built on `linux` instances through `github actions`. 
+
+These lectures are using the following python version
+
+```{code-cell} ipython
+!python --version
+```
+
+and the following package versions
+
+```{code-cell} ipython
+:tags: [hide-output]
+!conda list
+```


### PR DESCRIPTION
This PR

- [x] updates to `jupyter-book=1.0.3` and associated packages
- [x] migrates build cache to run weekly to save on costs
- [x] full execution check
- [x] re-enable build cache for ci workflow 