### PR TITLE
MAINT: enable manual triggering

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     # Execute cache weekly at 3am on Monday
     - cron:  '0 3 * * 1'
+  workflow_dispatch:
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR enables manual triggering of the `cache.yml` workflow