### PR TITLE
MAINT: Phase 1 - Add HTML archives to GitHub release assets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,6 +72,32 @@ jobs:
         run: |
           rm -r _build/.doctrees
           jb build lectures --path-output ./
+      # Create HTML archive for release assets
+      - name: Create HTML archive
+        shell: bash -l {0}
+        run: |
+          tar -czf lecture-python-advanced-html-${{ github.ref_name }}.tar.gz -C _build/html .
+          sha256sum lecture-python-advanced-html-${{ github.ref_name }}.tar.gz > html-checksum.txt
+
+          # Create metadata manifest
+          cat > html-manifest.json << EOF
+          {
+            "tag": "${{ github.ref_name }}",
+            "commit": "${{ github.sha }}",
+            "timestamp": "$(date -Iseconds)",
+            "size_mb": $(du -sm _build/html | cut -f1),
+            "file_count": $(find _build/html -type f | wc -l)
+          }
+          EOF
+      - name: Upload archives to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            lecture-python-advanced-html-${{ github.ref_name }}.tar.gz
+            html-checksum.txt
+            html-manifest.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy website to gh-pages
         uses: peaceiris/actions-gh-pages@v4
         with:


### PR DESCRIPTION
## Summary

Implements Phase 1 from the publishing workflow upgrade: HTML archive backup on releases.

## Changes

This PR adds steps to the `publish.yml` workflow to create and upload HTML archives as GitHub release assets:

1. Create HTML archive - Compresses `_build/html/` into a `.tar.gz` archive after the HTML build
2. Generate checksum - Creates SHA256 hash for integrity verification (`html-checksum.txt`)
3. Create manifest - Generates metadata file with build information (`html-manifest.json`)
4. Upload to release - Attaches all three files to the GitHub release using `softprops/action-gh-release@v1`

## Release Assets Created

Each `publish-*` tag will now include:

• 📦 `lecture-python-advanced-html-{tag}.tar.gz` - Full HTML site archive (~200-300 MB)
• 🔐 `html-checksum.txt` - SHA256 verification file
• 📋 `html-manifest.json` - Build metadata (tag, commit, timestamp, size, file count)

## Key Features

• ✅ Does not modify `_build/html/` directory (gh-pages deployment unaffected)
• ✅ Preserves existing release notes (no `body` override)
• ✅ Automatic tag detection from workflow context
• ✅ Creates safety net before Phase 2 (gh-pages history cleanup)

## Testing Plan

After merge, test with a `publish-test-*` tag to verify:

1. Workflow completes successfully
2. Three HTML assets are attached to release
3. Archive can be downloaded and extracted
4. Checksum verification works: `sha256sum -c html-checksum.txt`

## Related

- Reference implementation: [lecture-python.myst#662](https://github.com/QuantEcon/lecture-python.myst/pull/662)
- Tracking: See `meta/publishing-workflow-upgrade-tracking.md`