### PR TITLE
Update style guide action to v0.5

### DIFF
--- a/.github/workflows/style-guide.yml
+++ b/.github/workflows/style-guide.yml
@@ -10,7 +10,7 @@ jobs:
     if: contains(github.event.comment.body, '@qe-style-checker')
     runs-on: ubuntu-latest
     steps:
-      - uses: QuantEcon/action-style-guide@v0.3
+      - uses: QuantEcon/action-style-guide@v0.5
         with:
           mode: 'single'
           lectures-path: 'lectures/'


### PR DESCRIPTION
Updates the style guide GitHub Action from v0.3 to v0.5.

## What's New in v0.5

### Production Testing Infrastructure
- Production testing guide and test repository
- Automated regression testing

### New Features
- Custom PR labels via `pr-labels` input
- Useful for test repos

### Breaking Changes
- Now only supports `@qe-style-checker` syntax
- Removed legacy `@quantecon-style-guide` syntax

## Release Notes
See full release notes: https://github.com/QuantEcon/action-style-guide/releases/tag/v0.5.0

## Testing
Tested in [test-action-style-guide](https://github.com/QuantEcon/test-action-style-guide) repository.