### PR TITLE
Add fetch-depth: 0 to checkout action for changelog support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - name: Setup Anaconda
         uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - name: Setup Anaconda
         uses: conda-incubator/setup-miniconda@v3
         with:


### PR DESCRIPTION
This PR adds `fetch-depth: 0` to the checkout action in the CI workflow to ensure full git history is available for the changelog feature in the theme header.