### PR TITLE
FIX: quote glob in linkcheck.yml so the workflow file parses

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fail: false
           # Configuration is now specified in lychee.toml file
-          args: **/*.html
+          args: "**/*.html"
       - name: Create Issue From File
         if: steps.lychee.outputs.exit_code != 0
         uses: peter-evans/create-issue-from-file@v5


### PR DESCRIPTION
## Summary

One-character fix: `args: **/*.html` → `args: "**/*.html"` in `.github/workflows/linkcheck.yml`.

The unquoted glob is invalid YAML — a plain scalar cannot begin with `*` (the alias indicator) — so the workflow file fails to parse. Since #249, GitHub has been logging a 0-second "workflow file issue" failure named `.github/workflows/linkcheck.yml` on **every push to every branch**, including `main` (visible in the Actions tab as a long row of failed runs with no jobs).

The lychee invocation itself is unchanged; the workflow still only runs on its weekly schedule and `workflow_dispatch`.

Verified locally with `yaml.safe_load` — the file now parses.

cc @mmcky since this touches CI config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)