### PR TITLE
Enable minimal theme for proof/admonition directives

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -128,6 +128,8 @@ sphinx:
           "gG": "\\mathcal{G}"
           "hH": "\\mathcal{H}"
     mathjax_path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+    # sphinx-proof
+    proof_minimal_theme: true
     # sphinx-exercise
     exercise_style: "solution_follow_exercise"
     rediraffe_redirects:


### PR DESCRIPTION
## What

Sets `proof_minimal_theme: true` under the `sphinx-proof` config in `lectures/_config.yml`.

## Why

This project already loads the `sphinx_proof` extension but did not configure the minimal admonition theme. This change brings the styling in line with [lecture-python.myst](https://github.com/QuantEcon/lecture-python.myst), where `proof_minimal_theme: true` is already set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)