### PR TITLE
linkcheck: pass explicit `-f -` to tar when extracting from the curl pipe

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p _site
-          curl -fsSL "${{ steps.release.outputs.asset-url }}" | tar -xz -C _site
+          curl -fsSL "${{ steps.release.outputs.asset-url }}" | tar -xzf - -C _site
       - name: AI-Powered Link Checker
         uses: QuantEcon/action-link-checker@main
         with:


### PR DESCRIPTION
## Summary

Small hardening to the linkcheck workflow: make stdin extraction explicit (`tar -xzf -`) when extracting the release HTML archive from the `curl` pipe, rather than relying on GNU tar's compiled-in default archive device.

The current form works on `ubuntu-latest` (GNU tar defaults to stdin), but `-f -` removes the ambiguity and is more portable. Backported from Copilot review feedback on QuantEcon/lecture-python.myst#953, keeping the linkcheck download logic consistent across the migrated repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
