### PR TITLE
publish: fix hyphenated page-url output reference (env URL)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page-url }}
+      url: ${{ steps.deployment.outputs['page-url'] }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

Small fix to the `github-pages` deployment `environment.url` in `publish.yml`. The value referenced the action's `page-url` output with **dot notation**:

```yaml
url: ${{ steps.deployment.outputs.page-url }}
```

In GitHub Actions expressions a hyphen in dot notation is parsed as subtraction (`page` minus `url`), so this doesn't resolve to the output. The fix uses index syntax:

```yaml
url: ${{ steps.deployment.outputs['page-url'] }}
```

`quantecon/actions/publish-gh-pages` does expose an output named `page-url` (hyphenated), so index syntax is required to read it.

## Impact

Cosmetic only — `environment.url` sets the clickable link shown on the deployment in the repo's Environments/Deployments UI. Publishing and the live site are unaffected (this line has been deploying fine as-is). This just makes that convenience link resolve correctly.

Caught by Copilot review of the datascience migration (QuantEcon/lecture-datascience.myst#280); the same line came from the shared reference used across the family, so this applies the fix to the already-merged repos too. Part of QuantEcon/meta#282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
