### PR TITLE
CI: gate the first jb build so notebook errors cannot pass green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,18 @@ jobs:
       - name: Build PDF from LaTeX
         shell: bash -l {0}
         run: |
-          jb build lectures --builder pdflatex --path-output ./ -n --keep-going
+          # This is the FIRST `jb build` in the workflow, and `execute_notebooks: "cache"`
+          # means only the first build actually executes notebooks — the later
+          # tojupyter and HTML builds read the cache. So this is the step where a
+          # CellExecutionError surfaces, and therefore the step that has to gate.
+          #
+          # `set -eo pipefail` is required as well as `-W`: `shell: bash -l {0}` is a
+          # custom shell spec, so GitHub does not inject `-eo pipefail` (it only does
+          # that for the bare `shell: bash` shorthand). Without it a failing `jb build`
+          # would be masked by the trailing mkdir/cp, whose exit code becomes the
+          # step's — and `--keep-going` guarantees the PDF exists for `cp` to succeed on.
+          set -eo pipefail
+          jb build lectures --builder pdflatex --path-output ./ -n -W --keep-going
           mkdir -p _build/html/_pdf
           cp -u _build/latex/*.pdf _build/html/_pdf
       - name: Build Download Notebooks (sphinx-tojupyter)


### PR DESCRIPTION
Part of QuantEcon/meta#340.

## The problem

`Build PDF from LaTeX` is the **first** `jb build` in this workflow, and `lectures/_config.yml` sets `execute_notebooks: "cache"` — so it is the only build that actually executes notebooks; the later tojupyter and HTML builds read the cache. That makes it the step where a `CellExecutionError` surfaces.

It could not fail, for two independent reasons:

- **No `-W`.** It ran with `-n --keep-going`, so a `CellExecutionError` was a non-fatal warning.
- **Its exit code was `cp`'s, not `jb build`'s.** The step runs three commands under `shell: bash -l {0}`, and GitHub only injects `-eo pipefail` for the bare `shell: bash` shorthand — an explicit custom shell spec gets neither `-e` nor `-o pipefail`. So a failing `jb build` was followed by `mkdir` and `cp`, and the step exited with `cp`'s status. `--keep-going` makes this worse rather than better, because it forces Sphinx to emit output despite the errors, guaranteeing the PDF exists for `cp` to succeed on.

Either fix alone is insufficient. Both are applied, to one step.

## Note on which step

The rule is **"gate the first `jb build`"**, not "gate a particular step name". Here the LaTeX step runs first; in `lecture-python.myst`, `lecture-python-programming` and `lecture-jax` the notebooks step does, so those get a one-line `set -eo pipefail` instead. The audit table in QuantEcon/meta#340 records which step applies per repo.

## Verified before the change

- **No `raises-exception` tags** anywhere in `lectures/` — nothing is relying on an error being tolerated.
- **All 64 published lecture pages** on python-advanced.quantecon.org were scanned for execution-error markers (`output_error`, tracebacks, ANSI red). **Zero hits.**

Since this step has never been able to fail, CI on this PR is the first real exercise of it. `-W` also promotes Sphinx warnings to errors, and the LaTeX builder emits warnings the HTML builder does not. If CI goes red it has found something genuine that was previously silent, and that should be fixed rather than the flags softened.

Refs QuantEcon/meta#340

🤖 Generated with [Claude Code](https://claude.com/claude-code)
