### PR TITLE
Pin the link checker to v1 and declare known false positives

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -32,10 +32,25 @@ jobs:
           mkdir -p _site
           curl -fsSL "${{ steps.release.outputs.asset-url }}" | tar -xzf - -C _site
       - name: AI-Powered Link Checker
-        uses: QuantEcon/action-link-checker@main
+        uses: QuantEcon/action-link-checker@v1
         with:
           html-path: '_site'
           fail-on-broken: 'false'
           silent-codes: '403,503'
           ai-suggestions: 'true'
           create-issue: 'true'
+          # Known false positives. The first five mirror the linkcheck_ignore
+          # list in lectures/_config.yml, which Sphinx reads and this checker
+          # cannot see; keep the two in step. FRED throttles datacenter IP
+          # ranges, so it times out from a runner while serving readers fine.
+          #
+          # Deliberately NOT listed: the quantecon.org and ideas.repec.org
+          # links currently reported are real 404s and want fixing in the
+          # source, not suppressing here.
+          ignore-patterns: |
+            https://doi\.org/10\.3982/ECTA8070
+            https://doi\.org/10\.1086/261749
+            https://doi\.org/10\.1086/262078
+            https://keras\.io/
+            https://data\.oecd\.org/
+            https://fred\.stlouisfed\.org


### PR DESCRIPTION
Two changes to `linkcheck.yml`, following the [v1.1.0 release](https://github.com/QuantEcon/action-link-checker/releases/tag/v1.1.0) of the link checker.

## Pin `@main` → `@v1`

`@main` tracks whatever lands on the action's default branch, so this workflow absorbs behaviour changes without review. `@v1` is a moving tag that follows the 1.x line.

## Declare the known false positives — and only those

The most recent report, #369, lists six broken links, and unlike the sibling repos they are **not** all noise:

| Link | Status | Handling |
|---|---|---|
| `fred.stlouisfed.org` (×2) | 0 (Timeout) | Ignored — FRED throttles datacenter IPs |
| `ideas.repec.org/a/bla/jfinan/...` | 404 | **Left reported** |
| `python-intro.quantecon.org/optgrowth.html` (×2) | 404 | **Left reported** |
| `python.quantecon.org/optgrowth.html#exercises` | 404 | **Left reported** |

Only the two FRED timeouts are suppressed. The four 404s are real HTTP responses from reachable servers, and the three `quantecon.org` ones look like genuine rot worth fixing in the source rather than hiding. The workflow carries a comment saying so, so nobody adds them to the list later by reflex.

`ignore-patterns` also mirrors the five patterns in `lectures/_config.yml`, which Sphinx reads and this checker never sees. A comment records that the two lists have to be kept in step.

## Existing issues

v1.1.0 stops the weekly duplicates: a recurring finding now refreshes one open issue rather than opening a new one. It does not close the five that already exist, so those want closing by hand.
