### PR TITLE
Read the three wave-C1 datasets from data-lectures (Track C)

### DIFF
--- a/lectures/hansen_jagannathan_1991.md
+++ b/lectures/hansen_jagannathan_1991.md
@@ -179,11 +179,7 @@ interchangeably.
 
 import json, urllib.request
 
-DATA_URL = (
-    "https://raw.githubusercontent.com/QuantEcon/lecture-python-advanced.myst/"
-    "refs/heads/main/lectures/_static/lecture_specific/"
-    "hansen_jagannathan_1991/hansen_jagannathan_1991_data.json"
-)
+DATA_URL = "https://github.com/QuantEcon/data-lectures/raw/main/lectures/hansen_jagannathan_1991_data.json"
 
 
 def _load_bundle(url):

--- a/lectures/subjective_beliefs_business_cycles.md
+++ b/lectures/subjective_beliefs_business_cycles.md
@@ -146,10 +146,10 @@ one-year-ahead inflation forecast and the shares of households answering
 the monthly unemployment rate.
 
 ```{code-cell} ipython3
-data_path = '_static/lecture_specific/subjective_beliefs_business_cycles/'
-macro_q = pd.read_csv(data_path + 'bbh_macro_quarterly.csv',
+data_url = 'https://github.com/QuantEcon/data-lectures/raw/main/lectures/'
+macro_q = pd.read_csv(data_url + 'bbh_macro_quarterly.csv',
                       index_col='YYYYQ')
-mich_m = pd.read_csv(data_path + 'bbh_michigan_monthly.csv',
+mich_m = pd.read_csv(data_url + 'bbh_michigan_monthly.csv',
                      index_col='yyyymm')
 ```
 


### PR DESCRIPTION
Repoints the three wave-C1 datasets at `QuantEcon/data-lectures`, where they landed byte-identical in QuantEcon/data-lectures#92.

## Both reads are collapsed, not patched

`subjective_beliefs_business_cycles.md` built its path from a shared `data_path` stem. Editing that line alone would have left both filenames appended to a `_static/lecture_specific/<lecture>/` segment that does not exist in the flat published tree — the wave-B2′ lesson. The two bbh files share the variable and so repoint together in one edit.

`hansen_jagannathan_1991.md` already read over a URL, so this is a URL-string edit rather than a path→URL conversion. The old URL was split across three adjacent string literals; the new one is **a single line**, deliberately. A whole-URL grep returns a confident **zero** against the wrapped form, which is exactly how a sweep misses a live reference — this session hit that trap more than once. It is now greppable in one piece.

## URL form

`github.com/QuantEcon/data-lectures/raw/main/lectures/<file>`, per the URL-forms table in data-lectures `AGENTS.md`. `raw.githubusercontent.com` is reserved for `lecture-wasm`, whose cells execute in the reader's browser and need a CORS-clean host; this repo is a CPython consumer, and wave B2′ used this form in `lecture-python.myst`.

The wave plan QuantEcon/workspace-lectures#45 step 2 prescribes the wasm form for this repo. That is wrong, and is noted on the plan.

## Proven not to change a figure

Not "the URL returns 200" — each lecture's own loading code was run against the old location and the new URL and the results compared:

| read | old | new | `.equals()` |
| --- | --- | --- | --- |
| `bbh_macro_quarterly.csv` | (260, 14) | (260, 14) | **True** — columns and index identical |
| `bbh_michigan_monthly.csv` | (507, 5) | (507, 5) | **True** — columns and index identical |
| hansen `annual` | (95, 4) | (95, 4) | **True** |
| hansen `monthly` | (334, 3) | (334, 3) | **True** |
| hansen `quarterly` | (270, 4) | (270, 4) | **True** |

The hansen bundle's raw JSON is byte-identical between the two URLs.

A basename sweep with a firing positive control and a zero negative control finds each of the three names exactly once, at its repointed read, and no `_static/lecture_specific/…` path reference to any of them remains.

## The local copies are retained

Deleting them here would 404 the already-published notebooks until someone tags a publish. The deletion is a follow-up PR after this one publishes.

That ordering matters more than usual for `hansen_jagannathan_1991_data.json`: it is fetched over the network **at cell-execution time**, so it has no stale-serving grace period at all — deleting it breaks every notebook and Colab reader the instant the blob leaves `main`, rather than after a cache rebuild.

## Deliberately not in this PR

`_load_bundle()`'s local-path fallback branch is now unreachable, since `DATA_URL` is always a URL. Removing it is behaviour-neutral, but it does not belong in a repoint whose entire claim is that nothing changed. Worth a follow-up, along with the `from pathlib import Path` import it is the only user of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
