### PR TITLE
CI: prune the restored _build/html before building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,15 @@ jobs:
           branch: main
           name: build-cache
           path: _build
+      # Prune the restored _build/html so files deleted from source stop being
+      # published: sphinx copies html_static_path in but never removes stale
+      # assets. `jb clean . --html` removes exactly _build/html, leaving
+      # .jupyter_cache (the expensive execution cache), _build/latex and
+      # _build/jupyter untouched. Must run BEFORE the PDF/notebook steps below,
+      # which stage output INTO _build/html.
+      - name: Prune restored HTML (drop stale assets deleted from source)
+        shell: bash -l {0}
+        run: jb clean . --html
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build PDF from LaTeX
         shell: bash -l {0}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,6 +63,15 @@ jobs:
           branch: main
           name: build-cache
           path: _build
+      # Prune the restored _build/html so files deleted from source stop being
+      # published: sphinx copies html_static_path in but never removes stale
+      # assets. `jb clean . --html` removes exactly _build/html, leaving
+      # .jupyter_cache (the expensive execution cache), _build/latex and
+      # _build/jupyter untouched. Must run BEFORE the PDF/notebook steps below,
+      # which stage output INTO _build/html.
+      - name: Prune restored HTML (drop stale assets deleted from source)
+        shell: bash -l {0}
+        run: jb clean . --html
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build PDF from LaTeX
         shell: bash -l {0}


### PR DESCRIPTION
Both `ci.yml` and `publish.yml` restore the cached `_build` artifact and build over it. Sphinx copies `html_static_path` into `_build/html/_static` but never prunes assets that have since been removed from source, so a file deleted from this repo keeps being published — in CI previews immediately, and on the live site until a clean weekly cache rebuild happens to intervene. This made deletion verification unreliable during the Track C migration: a reviewer looking at a preview cannot tell whether a deletion took effect.

This adds one step to both workflows, immediately after the cache restore and before the first build: `jb clean . --html`. Verified against the pinned jupyter-book 1.0.4.post1: `--html` removes exactly `_build/html` and nothing else — `_build/.jupyter_cache`, `_build/latex` and `_build/jupyter` are untouched, so the expensive notebook execution stays cached and the cost is one Sphinx write pass. Placement is load-bearing: the step must run before the PDF and notebook steps, which stage `_pdf` and `_notebooks` into `_build/html`.

No repo in the family has ever run `jb clean` in CI, so this PR's own CI run is the test: it should rebuild all pages from the pruned tree and come out green with a working Netlify preview.

Ports the prune from QuantEcon/workspace-lectures#41 — first repo of the nine in that issue's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)