### PR TITLE
Read the three wave-C2 datasets from data-lectures (Track C)

### DIFF
--- a/lectures/five_preferences.md
+++ b/lectures/five_preferences.md
@@ -59,7 +59,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib import rc
 from scipy import optimize, stats
-from scipy.io import loadmat
+import pandas as pd
 from matplotlib.collections import LineCollection
 from numba import njit
 ```
@@ -1845,7 +1845,7 @@ aversion associated with a logarithmic one-period utility function.
 :tags: [hide-input]
 
 # Load data
-data = loadmat('dataBHS.mat')
+data = pd.read_csv('https://github.com/QuantEcon/data-lectures/raw/main/lectures/dataBHS.csv')
 
 # Set parameter values
 μ_c = 0.004952
@@ -1857,7 +1857,7 @@ data = loadmat('dataBHS.mat')
 :tags: [hide-input]
 
 # Compute consumption growth
-c = data['c']
+c = data[['c']].to_numpy()   # keep the (236, 1) column shape of the source arrays
 c_growth = c[1:] - c[:-1]
 
 # Create histogram of consumption growth

--- a/lectures/match_transport.md
+++ b/lectures/match_transport.md
@@ -2231,8 +2231,8 @@ Then we sort  occupations by average log-earnings within each occupation.
 The resulting dataset is included in the dataset `acs_data_summary.csv`
 
 ```{code-cell} ipython3
-data_path = '_static/lecture_specific/match_transport/'
-occupation_df = pd.read_csv(data_path + 'acs_data_summary.csv')
+data_url = 'https://github.com/QuantEcon/data-lectures/raw/main/lectures/'
+occupation_df = pd.read_csv(data_url + 'acs_data_summary.csv')
 ```
 
 +++ {"user_expressions": []}

--- a/lectures/risk_aversion_or_mistaken_beliefs.md
+++ b/lectures/risk_aversion_or_mistaken_beliefs.md
@@ -1611,8 +1611,7 @@ mystnb:
     name: fig-us-yields
 ---
 data = pd.read_csv(
-    'https://raw.githubusercontent.com/QuantEcon/lecture-python-advanced.myst/refs/heads/'
-    'main/lectures/_static/lecture_specific/risk_aversion_or_mistaken_beliefs/fred_data.csv',
+    'https://github.com/QuantEcon/data-lectures/raw/main/lectures/fred_data.csv',
     parse_dates=['DATE'], index_col='DATE'
 )
 


### PR DESCRIPTION
Repoints the three wave-C2 reads to the data landed in QuantEcon/data-lectures#98, following the C1 pattern (QuantEcon/lecture-python-advanced.myst#372). All three use the CPython URL form `github.com/QuantEcon/data-lectures/raw/main/lectures/<file>` per that repo's AGENTS.md.

**`risk_aversion_or_mistaken_beliefs.md`** — the read was already an HTTP read of this repo's own raw URL, split across two string literals with the `refs/heads/main` spelling; collapsed to a single literal of the new URL (the audit rejects any non-`main` ref spelling for data-lectures reads, so the old spelling must not be copied).

**`match_transport.md`** — `data_path` (local `_static` prefix) becomes `data_url`; the prose sentence naming the dataset three lines above is unchanged and still accurate.

**`five_preferences.md`** — `loadmat('dataBHS.mat')` becomes `read_csv` of the converted `dataBHS.csv`, and `from scipy.io import loadmat` becomes `import pandas as pd` (the file's first pandas use). The `[['c']]` selection keeps the (236, 1) column shape of the source arrays, so the growth difference, `np.histogram`, and the `ax.hist` patch-container indexing (`lns1[2][0]`) all see shapes identical to the loadmat path. Measured before the edit: histogram counts and bin edges are identical under pandas' **default** parser, and the lecture's hardcoded μ_c/σ_c reproduce from the converted data to printed precision.

Deletion of the two local copies (`_static/.../fred_data.csv`, `_static/.../acs_data_summary.csv`) and of `lectures/dataBHS.mat` follows in a separate PR **after this one publishes** — `fred_data.csv` is fetched live at cell execution by every published notebook, so the repoint must be published before the old blob leaves `main`.

Sweep evidence: after the edit, a basename sweep (bash arrays, positive control: 5 data-lectures reads found) shows zero remaining non-data-lectures references to `fred_data`, `dataBHS`, or `hansen_jagannathan_1991_data`; the two remaining `acs_data_summary` hits are the accurate prose mention and the basename half of the new split read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)