### PR TITLE
five_preferences: enable usetex only where a latex binary exists

### DIFF
--- a/lectures/five_preferences.md
+++ b/lectures/five_preferences.md
@@ -54,6 +54,7 @@ We begin with some that we'll use to create some graphs.
 
 ```{code-cell} ipython3
 # Package imports
+import shutil
 import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -67,7 +68,10 @@ from numba import njit
 ```{code-cell} ipython3
 :tags: [hide-input]
 
-plt.rc('text', usetex=True)
+# Render text with LaTeX only where a latex binary exists (the build has
+# texlive); on latex-less runtimes such as Colab, fall back to mathtext
+# instead of raising at the first rendered figure.
+plt.rc('text', usetex=bool(shutil.which('latex')))
 plt.rc('font', size=18)
 plt.rc('axes', labelsize=20, titlesize=24)
 plt.rc('xtick', labelsize=18)


### PR DESCRIPTION
Option 1 from the issue: guard the rc setting with `shutil.which('latex')` so the published site keeps its current typography (CI installs texlive and renders exactly as before) while Colab and other latex-less runtimes fall back to matplotlib's mathtext instead of raising `RuntimeError: Failed to process string with tex` at the first rendered figure. This was the last blocker on the "open in Colab" path for the downloadable `five_preferences.ipynb` — the 2026-08-18 human Colab run got past the repointed data read and died here.

This lecture is the only `usetex=True` user in the repo (checked 2026-08-18 across `lectures/*.md`). The byte-identical copy in lecture-tools-techniques carries the same setting twice and gets the same guard together with its `.mat` repoint — see QuantEcon/lecture-tools-techniques#11.

After this publishes, a clean human Colab run of the downloadable notebook closes the last box on QuantEcon/data-lectures#84.

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)